### PR TITLE
Rename TestHydro to HydroForces

### DIFF
--- a/demos/DeepCWind/demo_DeepCWind_decay.cpp
+++ b/demos/DeepCWind/demo_DeepCWind_decay.cpp
@@ -102,7 +102,7 @@ int main(int argc, char* argv[]) {
     // set up hydro forces
     std::vector<std::shared_ptr<ChBody>> bodies;
     bodies.push_back(base);
-    TestHydro hydroforces(bodies, h5fname);
+    HydroForces hydroforces(bodies, h5fname);
 
     // for profiling
     auto start = std::chrono::high_resolution_clock::now();

--- a/demos/f3of/demo_F3OF_DT1.cpp
+++ b/demos/f3of/demo_F3OF_DT1.cpp
@@ -166,7 +166,7 @@ int main(int argc, char* argv[]) {
     bodies.push_back(base);
     bodies.push_back(flapFore);
     bodies.push_back(flapAft);
-    TestHydro hydroforces(bodies, h5fname, default_dont_add_waves);
+    HydroForces hydroforces(bodies, h5fname, default_dont_add_waves);
 
     // for profiling
     auto start = std::chrono::high_resolution_clock::now();

--- a/demos/f3of/demo_F3OF_DT2.cpp
+++ b/demos/f3of/demo_F3OF_DT2.cpp
@@ -172,7 +172,7 @@ int main(int argc, char* argv[]) {
     bodies.push_back(flapFore);
     bodies.push_back(flapAft);
 
-    TestHydro hydroforces(bodies, h5fname, default_dont_add_waves);
+    HydroForces hydroforces(bodies, h5fname, default_dont_add_waves);
 
     // for profiling
     auto start = std::chrono::high_resolution_clock::now();

--- a/demos/f3of/demo_F3OF_DT3.cpp
+++ b/demos/f3of/demo_F3OF_DT3.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[]) {
     bodies.push_back(base);
     bodies.push_back(flapFore);
     bodies.push_back(flapAft);
-    TestHydro hydroforces(bodies, h5fname, default_dont_add_waves);
+    HydroForces hydroforces(bodies, h5fname, default_dont_add_waves);
 
     // for profiling
     auto start = std::chrono::high_resolution_clock::now();

--- a/demos/oswec/demo_oswec_decay.cpp
+++ b/demos/oswec/demo_oswec_decay.cpp
@@ -191,7 +191,7 @@ int main(int argc, char* argv[]) {
     std::vector<std::shared_ptr<ChBody>> bodies;
     bodies.push_back(flap_body);
     bodies.push_back(base_body);
-    TestHydro blah(bodies, h5fname, default_dont_add_waves);
+    HydroForces blah(bodies, h5fname, default_dont_add_waves);
 
     // for profiling
     auto start = std::chrono::high_resolution_clock::now();

--- a/demos/oswec/demo_oswec_reg_waves.cpp
+++ b/demos/oswec/demo_oswec_reg_waves.cpp
@@ -206,7 +206,7 @@ int main(int argc, char* argv[]) {
         /*std::vector<std::shared_ptr<ChBody>> bodies;
         bodies.push_back(flap_body);
         bodies.push_back(base_body);*/
-        TestHydro hydro_forces(bodies, h5fname);
+        HydroForces hydro_forces(bodies, h5fname);
         hydro_forces.AddWaves(my_hydro_inputs);
 
         // for profiling

--- a/demos/rm3/demo_rm3_decay.cpp
+++ b/demos/rm3/demo_rm3_decay.cpp
@@ -126,7 +126,7 @@ int main(int argc, char* argv[]) {
     bodies.push_back(float_body1);
     bodies.push_back(plate_body2);
 
-    TestHydro hydroForces(bodies, h5fname, default_dont_add_waves);
+    HydroForces hydroForces(bodies, h5fname, default_dont_add_waves);
 
     //// Debug printing added mass matrix and system mass matrix
     // ChSparseMatrix M;

--- a/demos/rm3/demo_rm3_reg_waves.cpp
+++ b/demos/rm3/demo_rm3_reg_waves.cpp
@@ -127,7 +127,7 @@ int main(int argc, char* argv[]) {
     std::vector<std::shared_ptr<ChBody>> bodies;
     bodies.push_back(float_body1);
     bodies.push_back(plate_body2);
-    TestHydro hydro_forces(bodies, h5fname);
+    HydroForces hydro_forces(bodies, h5fname);
     hydro_forces.AddWaves(my_hydro_inputs);
 
     // for profiling

--- a/demos/sphere/demo_sphere_decay.cpp
+++ b/demos/sphere/demo_sphere_decay.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[]) {
     system.Add(sphereBody);
 
     // define wave parameters (not used in this demo)
-    // Todo define a way to use TestHydro without hydro_inputs/waves
+    // Todo define a way to use HydroForces without hydro_inputs/waves
     //HydroInputs my_hydro_inputs;
     //my_hydro_inputs.mode = WaveMode::noWaveCIC;
     // my_hydro_inputs.regular_wave_amplitude = 0.022;
@@ -97,7 +97,7 @@ int main(int argc, char* argv[]) {
     std::vector<std::shared_ptr<ChBody>> bodies;
     bodies.push_back(sphereBody);
 
-    TestHydro hydro_forces(bodies, h5fname);
+    HydroForces hydro_forces(bodies, h5fname);
     hydro_forces.AddWaves(default_dont_add_waves);
 
 

--- a/demos/sphere/demo_sphere_irreg_waves.cpp
+++ b/demos/sphere/demo_sphere_irreg_waves.cpp
@@ -118,8 +118,8 @@ int main(int argc, char* argv[]) {
 
     std::vector<std::shared_ptr<ChBody>> bodies;
     bodies.push_back(sphereBody);
-    // TestHydro hydro_forces(bodies, h5fname, my_hydro_inputs);
-    TestHydro hydro_forces(bodies, h5fname);
+    // HydroForces hydro_forces(bodies, h5fname, my_hydro_inputs);
+    HydroForces hydro_forces(bodies, h5fname);
     hydro_forces.AddWaves(my_hydro_inputs);
 
     // set up free surface from a mesh

--- a/demos/sphere/demo_sphere_reg_waves.cpp
+++ b/demos/sphere/demo_sphere_reg_waves.cpp
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) {
 
         std::vector<std::shared_ptr<ChBody>> bodies;
         bodies.push_back(sphereBody);
-        TestHydro hydro_forces(bodies, h5fname);
+        HydroForces hydro_forces(bodies, h5fname);
         hydro_forces.AddWaves(my_hydro_inputs);
         // for profiling
         auto start = std::chrono::high_resolution_clock::now();

--- a/include/hydroc/hydro_forces.h
+++ b/include/hydroc/hydro_forces.h
@@ -1,7 +1,7 @@
 /*********************************************************************
  * @file  hydro_forces.h
  *
- * @brief header file of TestHydro main class and helper classes \
+ * @brief header file of HydroForces main class and helper classes \
  * ComponentFunc and ForceFunc6d.
  *********************************************************************/
 // TODO: clean up include statements
@@ -31,7 +31,7 @@ using namespace chrono;
 using namespace chrono::fea;
 
 class ForceFunc6d;
-class TestHydro;
+class HydroForces;
 
 class ComponentFunc : public ChFunction {
   public:
@@ -93,10 +93,10 @@ class ForceFunc6d {
      * from H5FileInfo, also initializes ChBody that this force will be applied to.
      *
      * @param object which body in system this 6 dimensional force is being applied to
-     * @param all_hydro_forces_user gets TestHydro class where total force on all bodies \
+     * @param all_hydro_forces_user gets HydroForces class where total force on all bodies \
      * in the system is calculated so the components can be passed to ForceFunc6d to apply
      */
-    ForceFunc6d(std::shared_ptr<ChBody> object, TestHydro* all_hydro_forces_user);
+    ForceFunc6d(std::shared_ptr<ChBody> object, HydroForces* all_hydro_forces_user);
 
     /**
      * @brief copy constructor should check to see if this force has been added to this body yet
@@ -148,19 +148,19 @@ class ForceFunc6d {
     std::shared_ptr<ComponentFunc> force_ptrs[6];
     std::shared_ptr<ChForce> chrono_force;
     std::shared_ptr<ChForce> chrono_torque;
-    TestHydro* all_hydro_forces;  // pointer up to TestHydro object so coordinateFunc() knows where to go for calcs
+    HydroForces* all_hydro_forces;  // pointer up to HydroForces object so coordinateFunc() knows where to go for calcs
 };
 
 class ChLoadAddedMass;
 
-// TODO give TestHydro a better name, perhaps HydroForces ?
-// TODO split TestHydro class from its helper classes into new file above for clearer code
-class TestHydro {
+// TODO give HydroForces a better name, perhaps HydroForces ?
+// TODO split HydroForces class from its helper classes into new file above for clearer code
+class HydroForces {
   public:
     bool printed = false;
-    TestHydro()  = delete;
+    HydroForces()  = delete;
     /**
-     * @brief main constructor for TestHydro class, sets up vector of bodies, h5 file info, and hydro inputs.
+     * @brief main constructor for HydroForces class, sets up vector of bodies, h5 file info, and hydro inputs.
      *
      * Also initializes many persistent variables for force calculations from h5 file.
      *
@@ -169,12 +169,12 @@ class TestHydro {
      * @param h5_file_name name of h5 file where hydro data is stored
      * @param waves optional Wavebase parameter if using regular or irregular waves
      */
-    TestHydro(std::vector<std::shared_ptr<ChBody>> user_bodies,
+    HydroForces(std::vector<std::shared_ptr<ChBody>> user_bodies,
               std::string h5_file_name,
               std::shared_ptr<WaveBase> waves);
 
     /**
-     * @brief alternate constructor for TestHydro class, sets up vector of bodies, h5 file info, and hydro inputs.
+     * @brief alternate constructor for HydroForces class, sets up vector of bodies, h5 file info, and hydro inputs.
      *
      * Also initializes many persistent variables for force calculations from h5 file.
      * If no waves are given in main constructor, this constructor makes NoWave object and calls main constructor \
@@ -186,13 +186,13 @@ class TestHydro {
      * must be added to system in same order as provided here
      * @param h5_file_name name of h5 file where hydro data is stored
      */
-    TestHydro(std::vector<std::shared_ptr<ChBody>> user_bodies, std::string h5_file_name)
-        : TestHydro(user_bodies, h5_file_name, std::static_pointer_cast<WaveBase>(std::make_shared<NoWave>())) {}
+    HydroForces(std::vector<std::shared_ptr<ChBody>> user_bodies, std::string h5_file_name)
+        : HydroForces(user_bodies, h5_file_name, std::static_pointer_cast<WaveBase>(std::make_shared<NoWave>())) {}
 
-    // should only ever have 1 TestHydro object in a system to calc all the forces on all hydro bodies
+    // should only ever have 1 HydroForces object in a system to calc all the forces on all hydro bodies
     // don't try copying or moving this, many issues will arrise.
-    TestHydro(const TestHydro& old) = delete;
-    TestHydro operator=(const TestHydro& rhs) = delete;
+    HydroForces(const HydroForces& old) = delete;
+    HydroForces operator=(const HydroForces& rhs) = delete;
 
     /**
      * @brief Adds waves class to force calculations depending on if regular or irregular waves.

--- a/include/hydroc/hydro_forces.h
+++ b/include/hydroc/hydro_forces.h
@@ -153,7 +153,6 @@ class ForceFunc6d {
 
 class ChLoadAddedMass;
 
-// TODO give HydroForces a better name, perhaps HydroForces ?
 // TODO split HydroForces class from its helper classes into new file above for clearer code
 class HydroForces {
   public:

--- a/src/h5fileinfo.cpp
+++ b/src/h5fileinfo.cpp
@@ -81,6 +81,7 @@ HydroData H5FileInfo::readH5Data() {
         Init1D(userH5File, "simulation_parameters/w", data_to_init.reg_wave_data[i].freq_list);
         Init3D(userH5File, bodyName + "/hydro_coeffs/excitation/mag",
                data_to_init.reg_wave_data[i].excitation_mag_matrix);
+        // TODO does excitation_mag_matrix need to be squeezed to 2d data as well?
 
         // scale by rho * g
         data_to_init.reg_wave_data[i].excitation_mag_matrix =
@@ -89,6 +90,7 @@ HydroData H5FileInfo::readH5Data() {
         Init3D(userH5File, bodyName + "/hydro_coeffs/excitation/phase",
                data_to_init.reg_wave_data[i]
                    .excitation_phase_matrix);  // TODO does this also need to be scaled by rho * g?
+        //TODO does excitation_phase_matrix also need to be squeezed to 2d data?
 
         // irreg wave
         // Init3D(userH5File, bodyName + "/hydro_coeffs/excitation/re", excitation_re_matrix, re_dims);


### PR DESCRIPTION
Big rename of TestHydro to HydroForces. Everything builds and runs fine on my end. If someone else could check this still works on their machine that'd be great.

TestHydro was a placeholder name for this class, and it stuck around way too long. Finally renaming it to HydroForces. 