### PR TITLE
Update cmake config for usage as external package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,11 @@ target_link_options(HydroChrono BEFORE
 		${CHRONO_LINKER_FLAGS}
 )
 
+set_target_properties(HydroChrono
+	PROPERTIES
+	POSITION_INDEPENDENT_CODE ON
+)
+
 # temporary hack
 # seems there is no namespace target hdf5:: on linux
 # for HDF5 version 1.10 to 1.14 ?

--- a/cmake/HydroChronoConfig.cmake.in
+++ b/cmake/HydroChronoConfig.cmake.in
@@ -1,7 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(HDF5)
-find_dependency(Chrono)
+find_dependency(HDF5 NAMES hdf5 COMPONENTS CXX)
+find_dependency(Chrono CONFIG REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/HydroChronoTargets.cmake")


### PR DESCRIPTION
Necessary changes in cmake config for including HydroChrono as an external package to another project on Linux (WSL)