### PR TITLE
Fix UI compile issue for tests and demos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ string(TOLOWER ${LIB_TYPE} SEARCH_TYPE)
 if(HYDROCHRONO_ENABLE_IRRLICHT)
 	# If irrlicht is required chrono library must be compiled with irrlicht
 	find_package(Chrono COMPONENTS Irrlicht CONFIG REQUIRED)
+	add_compile_definitions(HYDROCHRONO_HAVE_IRRLICHT=1)
 else(HYDROCHRONO_ENABLE_IRRLICHT)
 	find_package(Chrono CONFIG REQUIRED)
 endif(HYDROCHRONO_ENABLE_IRRLICHT)
@@ -155,54 +156,47 @@ target_link_libraries(HydroChrono
 # ====================
 # Irrlicht GUI helper
 # ====================
-if(HYDROCHRONO_ENABLE_IRRLICHT)
 
-	add_library(HydroChronoGUI)
+add_library(HydroChronoGUI)
 
-	target_sources(
-		HydroChronoGUI
+target_sources(
+	HydroChronoGUI
 
-		PUBLIC
-		src/gui/guihelper.cpp
-	)
+	PUBLIC
+	src/gui/guihelper.cpp
+)
 
-	target_compile_features(HydroChronoGUI PUBLIC cxx_std_17)
+target_compile_features(HydroChronoGUI PUBLIC cxx_std_17)
 
 
-	target_include_directories(
-		HydroChronoGUI
+target_include_directories(
+	HydroChronoGUI
 
-		PUBLIC
-		
+	PUBLIC
 		$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 		$<INSTALL_INTERFACE:include>
-		${CHRONO_INCLUDE_DIRS} 		
-	)
+		${CHRONO_INCLUDE_DIRS}
+)
 
-	target_compile_definitions(HydroChronoGUI
-		PUBLIC
-			CHRONO_DATA_DIR=\"${CHRONO_DATA_DIR}\"
-		PRIVATE
-			HYDROCHRONO_HAVE_IRRLICHT=1			
-	)
-
-	target_compile_options(HydroChronoGUI BEFORE 
-		PUBLIC
-			${CHRONO_CXX_FLAGS}
-	)
-
-	target_link_options(HydroChronoGUI BEFORE 
-		PUBLIC
-			${CHRONO_LINKER_FLAGS}
-	)
-
-	target_link_libraries(HydroChronoGUI 
-		PRIVATE
-			${CHRONO_LIBRARIES}
-	)
-
-
+if(HYDROCHRONO_ENABLE_IRRLICHT)
 endif(HYDROCHRONO_ENABLE_IRRLICHT)
+
+target_compile_options(HydroChronoGUI BEFORE
+	PUBLIC
+		${CHRONO_CXX_FLAGS}
+)
+
+target_link_options(HydroChronoGUI BEFORE
+	PUBLIC
+		${CHRONO_LINKER_FLAGS}
+)
+
+target_link_libraries(HydroChronoGUI
+	PRIVATE
+		${CHRONO_LIBRARIES}
+)
+
+
 
 # ====================
 # DEMOS


### PR DESCRIPTION
This PR ensures that HydroChronoGUI is compiled. It is needed for compiling tests and demos even if Irrlicht is disabled.