### PR TITLE
Add JONSWAP spectrum + random seed

### DIFF
--- a/include/hydroc/wave_types.h
+++ b/include/hydroc/wave_types.h
@@ -239,6 +239,7 @@ struct IrregularWaveParams {
     double wave_height_ = 0.0;
     double wave_period_ = 0.0;
     double peak_enhancement_factor_ = 1.0;
+    int seed_ = 1;
 };
 
 class IrregularWaves : public WaveBase {
@@ -325,6 +326,7 @@ class IrregularWaves : public WaveBase {
     double wave_height_;
     double wave_period_;
     double peak_enhancement_factor_;
+    int seed_;
     std::vector<double> spectrum_;
     std::vector<double> time_data_;
     std::vector<double> free_surface_elevation_;

--- a/include/hydroc/wave_types.h
+++ b/include/hydroc/wave_types.h
@@ -13,6 +13,8 @@
 // todo move this helper function somewhere else?
 Eigen::VectorXd PiersonMoskowitzSpectrumHz(Eigen::VectorXd& f, double Hs, double Tp);
 
+Eigen::VectorXd JONSWAPSpectrumHz(Eigen::VectorXd& f, double Hs, double Tp, double gamma=3.3);
+
 std::vector<double> FreeSurfaceElevation(const Eigen::VectorXd& freqs_hz,
                                          const Eigen::VectorXd& spectral_densities,
                                          const Eigen::VectorXd& time_index,
@@ -232,10 +234,11 @@ struct IrregularWaveParams {
     unsigned int num_bodies_;
     double simulation_dt_;
     double simulation_duration_;
-    double ramp_duration_;
+    double ramp_duration_ = 0.0;
     std::string eta_file_path_;
     double wave_height_ = 0.0;
     double wave_period_ = 0.0;
+    double peak_enhancement_factor_ = 1.0;
 };
 
 class IrregularWaves : public WaveBase {
@@ -321,6 +324,7 @@ class IrregularWaves : public WaveBase {
     std::string eta_file_path_;
     double wave_height_;
     double wave_period_;
+    double peak_enhancement_factor_;
     std::vector<double> spectrum_;
     std::vector<double> time_data_;
     std::vector<double> free_surface_elevation_;

--- a/src/wave_types.cpp
+++ b/src/wave_types.cpp
@@ -481,7 +481,8 @@ IrregularWaves::IrregularWaves(const IrregularWaveParams& params)
       peak_enhancement_factor_(params.peak_enhancement_factor_),
       simulation_dt_(params.simulation_dt_),
       simulation_duration_(params.simulation_duration_),
-      ramp_duration_(params.ramp_duration_) {
+      ramp_duration_(params.ramp_duration_),
+      seed_(params.seed_) {
     std::cout << "Creating IrregularWaves object..." << std::endl;
     ex_irf_resampled_.resize(num_bodies_);
     ex_irf_time_resampled_.resize(num_bodies_);
@@ -737,7 +738,8 @@ void IrregularWaves::CreateFreeSurfaceElevation() {
     Eigen::VectorXd time_index = Eigen::VectorXd::LinSpaced(num_timesteps, 0, simulation_duration_);
 
     // Calculate the free surface elevation
-    free_surface_elevation_ = FreeSurfaceElevation(spectrum_frequencies_, spectral_densities_, time_index, sim_data_.water_depth);
+    free_surface_elevation_ =
+        FreeSurfaceElevation(spectrum_frequencies_, spectral_densities_, time_index, sim_data_.water_depth, seed_);
 
     // Apply ramp if ramp_duration is greater than 0
     if (ramp_duration_ > 0.0) {


### PR DESCRIPTION
This PR adds the JONSWAP spectrum, and is calculated in the code by first getting the spectral densities from the Pierson-Moskowitz spectrum and then scaling it with the peak enhancement factor factor. By default, the peak enhancement factor is 1.0, which keeps the spectrum equivalent to Pierson-Moskowitz (as used in tests).
The random seed was also exposed in the IrregularWaveParams struct so it can be set by the user.