### PR TITLE
Interpolate when doing excitation force convolution

### DIFF
--- a/doc/user/_theory/theory.rst
+++ b/doc/user/_theory/theory.rst
@@ -117,7 +117,7 @@ This transform allows the frequency domain coefficients, :math:`B(\omega)`, to b
 Wave excitation force, :math:`F_{exc}(t)`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following method to compute the wave excitation force involves convolution between the excitation impulse response function :math:`K_{exc}(t)` and the wave elevation time sequence :math:`\eta(t)`:
+The following method to compute the wave excitation force involves convolution between the excitation Impulse Response Function (IRF) :math:`K_{exc}(t)` and the wave elevation time sequence :math:`\eta(t)`:
 
 .. math::
     :label: f_ex
@@ -125,6 +125,8 @@ The following method to compute the wave excitation force involves convolution b
     F_{exc}(t) = \int_{-\infty}^{+\infty} K_{exc}(\tau) \eta(x, y, t-\tau) d\tau
 
 By amalgamating these forces into the equation of motion, one can effectively model the behavior of a multibody oceanic system influenced by hydrodynamic forces.
+
+In HydroChrono, the force is computed through trapezoidal integration by discretizing at the time values given by the excitation IRF time array relative to the current simulation time step. Linear interpolation is done for the free surface elevation if a given time value is between two values of the time series of the precomputed free surface elevation.
 
 
 .. rubric:: Footnotes

--- a/include/hydroc/helper.h
+++ b/include/hydroc/helper.h
@@ -3,40 +3,48 @@
 
 #pragma once
 
-#include <string>
-#include <iostream>
+#include <Eigen/Dense>  // Need for the container function
 #include <fstream>
-#include <Eigen/Dense> // Need for the container function
-
+#include <iostream>
+#include <string>
 
 #ifndef M_PI
     #define M_PI 3.14159265358979323846
 #endif
+
+/**@brief Returns last index of vector element below value.
+ *
+ * @param value Input value
+ * @param ticks Array of ticks from which to find lower-bound index (assuming ascending order)
+ *
+ */
+size_t get_lower_index(double value, const std::vector<double>& ticks);
+
 /**@brief Base namespace for HydroChrono library
- * 
-*/
+ *
+ */
 namespace hydroc {
 
 /**@brief Set initial environment
- * 
+ *
  * Use command line argument or env variables to set s
  * ome static data at initialization.
- * 
+ *
  * Set the main data directory ..
- * 
+ *
  * @param argc number of argument (same as for main function)
- * @param argv arguments of main function 
+ * @param argv arguments of main function
  * @return 1 on error 0 else
-*/
+ */
 int SetInitialEnvironment(int argc, char* argv[]) noexcept;
 
 /**@brief Get base name of data directory
- * 
+ *
  * @return the string containing the path in standard format
-*/
+ */
 std::string getDataDir() noexcept;
 template <typename T>
-void WriteDataToFile(const std::vector<T>& data, const std::string& filename){
+void WriteDataToFile(const std::vector<T>& data, const std::string& filename) {
     std::ofstream outFile(filename);
     if (outFile.is_open()) {
         for (const auto& item : data) {
@@ -66,7 +74,8 @@ void WriteContainerToFile(const Container& container, const std::string& file_na
  * @param file_name file to write container to
  */
 template <>
-void inline WriteContainerToFile<std::vector<double>>(const std::vector<double>& container, const std::string& file_name) {
+void inline WriteContainerToFile<std::vector<double>>(const std::vector<double>& container,
+                                                      const std::string& file_name) {
     std::ofstream output_file(file_name);
 
     if (!output_file) {
@@ -103,6 +112,6 @@ void inline WriteContainerToFile<Eigen::VectorXd>(const Eigen::VectorXd& contain
     output_file.close();
 };
 
-} // end namespace hydroc
+}  // end namespace hydroc
 
 #endif

--- a/include/hydroc/wave_types.h
+++ b/include/hydroc/wave_types.h
@@ -13,14 +13,13 @@
 // todo move this helper function somewhere else?
 Eigen::VectorXd PiersonMoskowitzSpectrumHz(Eigen::VectorXd& f, double Hs, double Tp);
 
-Eigen::VectorXd JONSWAPSpectrumHz(Eigen::VectorXd& f, double Hs, double Tp, double gamma=3.3);
+Eigen::VectorXd JONSWAPSpectrumHz(Eigen::VectorXd& f, double Hs, double Tp, double gamma = 3.3);
 
 std::vector<double> FreeSurfaceElevation(const Eigen::VectorXd& freqs_hz,
                                          const Eigen::VectorXd& spectral_densities,
                                          const Eigen::VectorXd& time_index,
                                          double water_depth,
                                          int seed = 1);
-
 
 enum class WaveMode {
     /// @brief No waves
@@ -187,7 +186,7 @@ class RegularWave : public WaveBase {
 };
 
 //// class to instantiate WaveBase for irregular waves
-//class IrregularWave : public WaveBase {
+// class IrregularWave : public WaveBase {
 //  public:
 //    IrregularWave();
 //    IrregularWave(unsigned int num_b);
@@ -207,7 +206,8 @@ class RegularWave : public WaveBase {
 //    double ramp_duration;
 //    Eigen::VectorXd eta;
 //
-//    void AddH5Data(std::vector<HydroData::IrregularWaveInfo>& irreg_h5_data, HydroData::SimulationParameters& sim_data);
+//    void AddH5Data(std::vector<HydroData::IrregularWaveInfo>& irreg_h5_data, HydroData::SimulationParameters&
+//    sim_data);
 //
 //  private:
 //    unsigned int num_bodies;
@@ -222,8 +222,8 @@ class RegularWave : public WaveBase {
 //
 //    // Eigen::MatrixXd GetExcitationIRF(int b) const;
 //    Eigen::VectorXd ResampleTime(const Eigen::VectorXd& t_old, const double dt_new);
-//    Eigen::MatrixXd ResampleVals(const Eigen::VectorXd& t_old, Eigen::MatrixXd& vals_old, const Eigen::VectorXd& t_new);
-//    double ExcitationConvolution(int body, int dof, double time);
+//    Eigen::MatrixXd ResampleVals(const Eigen::VectorXd& t_old, Eigen::MatrixXd& vals_old, const Eigen::VectorXd&
+//    t_new); double ExcitationConvolution(int body, int dof, double time);
 //
 //    void CreateSpectrum();
 //    void IrregularWave::CreateFreeSurfaceElevation();
@@ -236,10 +236,10 @@ struct IrregularWaveParams {
     double simulation_duration_;
     double ramp_duration_ = 0.0;
     std::string eta_file_path_;
-    double wave_height_ = 0.0;
-    double wave_period_ = 0.0;
+    double wave_height_             = 0.0;
+    double wave_period_             = 0.0;
     double peak_enhancement_factor_ = 1.0;
-    int seed_ = 1;
+    int seed_                       = 1;
 };
 
 class IrregularWaves : public WaveBase {
@@ -300,12 +300,13 @@ class IrregularWaves : public WaveBase {
     Eigen::Vector3<double> GetWaveMeshVelocity();
 
     // user input // TODO add default values in case user doesn't initialize these?
-    //double wave_height_;
-    //double wave_period_;
-    //double simulation_duration_;
-    //double simulation_dt_;
-    //double ramp_duration_;
-    //Eigen::VectorXd eta_;  // public for mesh printing functions, TODO maybe make those friends, so this can be private?
+    // double wave_height_;
+    // double wave_period_;
+    // double simulation_duration_;
+    // double simulation_dt_;
+    // double ramp_duration_;
+    // Eigen::VectorXd eta_;  // public for mesh printing functions, TODO maybe make those friends, so this can be
+    // private?
 
     /**
      * @brief Initializes other member variables for timestep calculations later.
@@ -333,8 +334,8 @@ class IrregularWaves : public WaveBase {
     bool spectrumCreated_;
 
     const WaveMode mode_ = WaveMode::irregular;
-    //unsigned int num_bodies_;
-    //const WaveMode mode_ = WaveMode::irregular;
+    // unsigned int num_bodies_;
+    // const WaveMode mode_ = WaveMode::irregular;
     std::vector<HydroData::IrregularWaveInfo> wave_info_;
     HydroData::SimulationParameters sim_data_;
     std::vector<Eigen::MatrixXd> ex_irf_resampled_;

--- a/include/hydroc/wave_types.h
+++ b/include/hydroc/wave_types.h
@@ -366,6 +366,11 @@ class IrregularWaves : public WaveBase {
     /**
      * @brief Calculates the component of force from Convolution integral for specified body, dof, time.
      *
+     * The discretization uses the time series of the of the IRF relative to the current time step.
+     * Linear interpolation is done for the free surface elevation if time_sim-time_irf is between two
+     * values of the time series of the precomputed free surface elevation.
+     * Trapezoidal integration is used to compute the force.
+     *
      * @param body which body currently calculating for
      * @param dof which degree of freedom to calculate force value for
      * @param time the time to compute force for

--- a/include/hydroc/wave_types.h
+++ b/include/hydroc/wave_types.h
@@ -17,7 +17,7 @@ Eigen::VectorXd JONSWAPSpectrumHz(Eigen::VectorXd& f, double Hs, double Tp, doub
 
 std::vector<double> FreeSurfaceElevation(const Eigen::VectorXd& freqs_hz,
                                          const Eigen::VectorXd& spectral_densities,
-                                         const Eigen::VectorXd& time_index,
+                                         const Eigen::VectorXd& time_array,
                                          double water_depth,
                                          int seed = 1);
 
@@ -330,7 +330,8 @@ class IrregularWaves : public WaveBase {
     int seed_;
     std::vector<double> spectrum_;
     std::vector<double> time_data_;
-    std::vector<double> free_surface_elevation_;
+    std::vector<double> free_surface_elevation_sampled_;
+    std::vector<double> free_surface_time_sampled_;
     bool spectrumCreated_;
 
     const WaveMode mode_ = WaveMode::irregular;

--- a/include/hydroc/wave_types.h
+++ b/include/hydroc/wave_types.h
@@ -339,8 +339,9 @@ class IrregularWaves : public WaveBase {
     // const WaveMode mode_ = WaveMode::irregular;
     std::vector<HydroData::IrregularWaveInfo> wave_info_;
     HydroData::SimulationParameters sim_data_;
-    std::vector<Eigen::MatrixXd> ex_irf_resampled_;
-    std::vector<Eigen::VectorXd> ex_irf_time_resampled_;
+    std::vector<Eigen::MatrixXd> ex_irf_sampled_;
+    std::vector<Eigen::VectorXd> ex_irf_time_sampled_;
+    std::vector<Eigen::VectorXd> ex_irf_width_sampled_;
     Eigen::VectorXd spectrum_frequencies_;
     Eigen::VectorXd spectral_densities_;
     std::string mesh_file_name_;
@@ -352,30 +353,15 @@ class IrregularWaves : public WaveBase {
 
     Eigen::MatrixXd GetExcitationIRF(int b) const;
 
-    /**
-     * @brief resamples irf time vector from old time vector and new timestep.
+    /** @brief Resamples IRF time, widths, and values.
      *
-     * Creates a resized time vector that starts and ends at the same values as t_old and has timestep t_new.
-     *
-     * @param t_old reference to old time vector from h5 file, the first and last element are transfered to the first
-     * and last element of t_new (return val)
-     * @param dt_new the time step to use in resampled vector, typically the timestep of chrono simulation
-     *
-     * @return newly sized vector that looks like \
-     * (t_old[0], t_old[0] + dt_new, t_old[0] + 2*dt_new, ... , t_old[t_old.size()-1])
+     * @param dt Time step value to resample
      */
-    Eigen::VectorXd ResampleTime(const Eigen::VectorXd& t_old, const double dt_new);
+    void ResampleIRF(double dt);
 
-    /**
-     * @brief Creates a resized values vector to interpolate values for a new timestep.
-     *
-     * @param t_old reference to old time vector from h5 file
-     * @param vals_old the original values corresponding to the times in t_old from h5 file
-     * @param t_new resampled times (return value from ResampleTime()) to use in interpolation
-     *
-     * @return matrix for interpolated vals_old over t_new
+    /** @brief Calculates width (used for excitation convolution).
      */
-    Eigen::MatrixXd ResampleVals(const Eigen::VectorXd& t_old, Eigen::MatrixXd& vals_old, const Eigen::VectorXd& t_new);
+    void IrregularWaves::CalculateWidthIRF();
 
     /**
      * @brief Calculates the component of force from Convolution integral for specified body, dof, time.

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -5,6 +5,22 @@
 #include <memory>
 #include <vector>
 
+size_t get_lower_index(double value, const std::vector<double>& ticks) {
+    auto it = std::upper_bound(ticks.begin(), ticks.end(), value);
+    // get nearest-below index
+    size_t idx = it - ticks.begin() - 1;
+    // remove one if equal to value
+    if (ticks[idx] == value) {
+        idx -= 1;
+    }
+    if (idx <= 0 || idx >= ticks.size() - 1) {
+        throw std::runtime_error("Could not find index for value " + std::to_string(value) + " in array with bounds (" +
+                                 std::to_string(ticks.front()) + ", " + std::to_string(ticks.back()) + ").");
+    }
+    // return index
+    return idx;
+}
+
 using std::filesystem::path;
 
 static path DATADIR{};

--- a/src/wave_types.cpp
+++ b/src/wave_types.cpp
@@ -3,9 +3,9 @@
  *
  * @brief implementation file for Wavebase and classes inheriting from WaveBase.
  *********************************************************************/
+#include <hydroc/helper.h>
 #include <hydroc/wave_types.h>
 #include <unsupported/Eigen/Splines>
-#include <hydroc/helper.h>
 
 Eigen::VectorXd NoWave::GetForceAtTime(double t) {
     unsigned int dof = num_bodies_ * 6;
@@ -89,15 +89,15 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //// Irregular wave class definitions:
-//IrregularWave::IrregularWave() {
+// IrregularWave::IrregularWave() {
 //    num_bodies = 1;
 //}
 //
-//IrregularWave::IrregularWave(unsigned int num_b) {
+// IrregularWave::IrregularWave(unsigned int num_b) {
 //    num_bodies = num_b;
 //}
 //
-//void IrregularWave::Initialize() {
+// void IrregularWave::Initialize() {
 //    std::vector<Eigen::MatrixXd> ex_irf_old(num_bodies);
 //    std::vector<Eigen::VectorXd> ex_irf_time_old(num_bodies);
 //    for (int b = 0; b < num_bodies; b++) {
@@ -120,7 +120,7 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
 //    CreateFreeSurfaceElevation();  // eta initialized in here, and output to eta.txt
 //}
 //
-//Eigen::MatrixXd IrregularWave::ResampleVals(const Eigen::VectorXd& t_old,
+// Eigen::MatrixXd IrregularWave::ResampleVals(const Eigen::VectorXd& t_old,
 //                                            Eigen::MatrixXd& vals_old,
 //                                            const Eigen::VectorXd& t_new) {
 //    assert(vals_old.rows() == 6);
@@ -140,7 +140,7 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
 //    return vals_new;
 //}
 //
-//Eigen::VectorXd IrregularWave::ResampleTime(const Eigen::VectorXd& t_old, const double dt_new) {
+// Eigen::VectorXd IrregularWave::ResampleTime(const Eigen::VectorXd& t_old, const double dt_new) {
 //    double dt_old    = t_old[1] - t_old[0];
 //    int size_new     = static_cast<int>(ceil(t_old.size() * dt_old / dt_new));
 //    double t_initial = t_old[0];
@@ -161,13 +161,13 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
 //    return t_new;
 //}
 //
-//void IrregularWave::AddH5Data(std::vector<HydroData::IrregularWaveInfo>& irreg_h5_data,
+// void IrregularWave::AddH5Data(std::vector<HydroData::IrregularWaveInfo>& irreg_h5_data,
 //                              HydroData::SimulationParameters& sim_data) {
 //    wave_info = irreg_h5_data;
 //    sim_data  = sim_data;
 //}
 //
-//Eigen::VectorXd IrregularWave::GetForceAtTime(double t) {
+// Eigen::VectorXd IrregularWave::GetForceAtTime(double t) {
 //    unsigned int total_dofs = num_bodies * 6;
 //    Eigen::VectorXd f(total_dofs);
 //    // initialize the force here:
@@ -199,7 +199,7 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
 ////    return wave_info[b].excitation_irf_matrix;
 ////}
 //
-//double IrregularWave::ExcitationConvolution(int body, int dof, double time) {
+// double IrregularWave::ExcitationConvolution(int body, int dof, double time) {
 //    double f_ex  = 0.0;
 //    double width = ex_irf_time_resampled[body][1] - ex_irf_time_resampled[body][0];
 //    //std::cout << "width=" << width << std::endl;
@@ -218,7 +218,7 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
 //    return f_ex;
 //}
 //
-//Eigen::VectorXd IrregularWave::SetSpectrumFrequencies(double start, double end, int num_points) {
+// Eigen::VectorXd IrregularWave::SetSpectrumFrequencies(double start, double end, int num_points) {
 //    Eigen::VectorXd result(num_points);
 //    double step = (end - start) / (num_points - 1);
 //
@@ -231,7 +231,7 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
 //    return result;
 //}
 //
-//void IrregularWave::CreateSpectrum() {
+// void IrregularWave::CreateSpectrum() {
 //    // Define the frequency vector
 //    spectrum_frequencies = Eigen::VectorXd::LinSpaced(1000, 0.001, 1.0);
 //
@@ -255,7 +255,7 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
 //    }
 //}
 //
-//void IrregularWave::CreateFreeSurfaceElevation() {
+// void IrregularWave::CreateFreeSurfaceElevation() {
 //    // Create a time index vector
 //    // UpdateNumTimesteps();
 //    int num_timesteps = static_cast<int>(simulation_duration / simulation_dt) + 1;
@@ -296,7 +296,6 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
 //    // WriteFreeSurfaceMeshObj(free_surface_3d_pts, free_surface_triangles, "fse_mesh.obj");
 //}
 
-
 std::vector<double> ComputeWaveNumbers(const std::vector<double>& omegas,
                                        double water_depth,
                                        double g           = 9.81,
@@ -330,10 +329,10 @@ std::vector<double> ComputeWaveNumbers(const std::vector<double>& omegas,
 }
 
 std::vector<double> FreeSurfaceElevation(const Eigen::VectorXd& freqs_hz,
-                                     const Eigen::VectorXd& spectral_densities,
-                                     const Eigen::VectorXd& time_index,
-                                     double water_depth,
-                                     int seed) {
+                                         const Eigen::VectorXd& spectral_densities,
+                                         const Eigen::VectorXd& time_index,
+                                         double water_depth,
+                                         int seed) {
     double delta_f = freqs_hz(Eigen::last) / freqs_hz.size();
     std::vector<double> omegas(freqs_hz.size());
 
@@ -377,7 +376,7 @@ std::vector<double> FreeSurfaceElevation(const Eigen::VectorXd& freqs_hz,
     return eta;
 }
 
-//void IrregularWave::SetUpWaveMesh(std::string filename) {
+// void IrregularWave::SetUpWaveMesh(std::string filename) {
 //    mesh_file_name             = filename;
 //    int num_timesteps          = static_cast<int>(simulation_duration / simulation_dt) + 1;
 //    Eigen::VectorXd time_index = Eigen::VectorXd::LinSpaced(num_timesteps, 0, simulation_duration);
@@ -452,16 +451,15 @@ void WriteFreeSurfaceMeshObj(const std::vector<std::array<double, 3>>& points,
     out.close();
 }
 
-//std::string IrregularWave::GetMeshFile() {
+// std::string IrregularWave::GetMeshFile() {
 //    return mesh_file_name;
 //}
 //
-//Eigen::Vector3<double> IrregularWave::GetWaveMeshVelocity() {
+// Eigen::Vector3<double> IrregularWave::GetWaveMeshVelocity() {
 //    return Eigen::Vector3d(1.0, 0, 0);
 //}
 
-
-//IrregularWaves::IrregularWaves(const std::string& eta_file_path, double wave_height, double wave_period)
+// IrregularWaves::IrregularWaves(const std::string& eta_file_path, double wave_height, double wave_period)
 //    : eta_file_path(eta_file_path), wave_height(wave_height), wave_period(wave_period) {
 //    if (!eta_file_path.empty()) {
 //        ReadEtaFromFile();
@@ -501,7 +499,7 @@ IrregularWaves::IrregularWaves(const IrregularWaveParams& params)
     std::vector<Eigen::MatrixXd> ex_irf_old(num_bodies_);
     std::vector<Eigen::VectorXd> ex_irf_time_old(num_bodies_);
 
-    //for (unsigned int b = 0; b < num_bodies; b++) {
+    // for (unsigned int b = 0; b < num_bodies; b++) {
     //    std::cout << "get excitation IRFs..." << std::endl;
     //    ex_irf_old[b]      = GetExcitationIRF(b);
     //    std::cout << "get excitation IRF time..." << std::endl;
@@ -509,8 +507,8 @@ IrregularWaves::IrregularWaves(const IrregularWaveParams& params)
     //}
 
     //// Resample excitation IRF time series
-    //std::cout << "resample IRFs..." << std::endl;
-    //for (unsigned int b = 0; b < num_bodies; b++) {
+    // std::cout << "resample IRFs..." << std::endl;
+    // for (unsigned int b = 0; b < num_bodies; b++) {
     //    ex_irf_time_resampled[b] = ResampleTime(ex_irf_time_old[b], simulation_dt);
     //    ex_irf_resampled[b]      = ResampleVals(ex_irf_time_old[b], ex_irf_old[b], ex_irf_time_resampled[b]);
     //}
@@ -582,10 +580,10 @@ Eigen::MatrixXd IrregularWaves::GetExcitationIRF(int b) const {
 void IrregularWaves::AddH5Data(std::vector<HydroData::IrregularWaveInfo>& irreg_h5_data,
                                HydroData::SimulationParameters& sim_data) {
     wave_info_ = irreg_h5_data;
-    sim_data  = sim_data;  // Note: This line seems to be redundant as mentioned before.
+    sim_data   = sim_data;  // Note: This line seems to be redundant as mentioned before.
 
     //// Add this loop to print the values of wave_info[b].excitation_irf_matrix for each body
-    //for (unsigned int b = 0; b < num_bodies; ++b) {
+    // for (unsigned int b = 0; b < num_bodies; ++b) {
     //    std::cout << "wave_info[" << b << "].excitation_irf_matrix:\n";
     //    std::cout << wave_info[b].excitation_irf_matrix << std::endl;
     //}
@@ -614,13 +612,13 @@ Eigen::VectorXd IrregularWaves::GetForceAtTime(double t) {
             f[b_offset + dof]     = f_dof;
         }
     }
-    
+
     return f;
 }
 
 Eigen::MatrixXd IrregularWaves::ResampleVals(const Eigen::VectorXd& t_old,
-                                            Eigen::MatrixXd& vals_old,
-                                            const Eigen::VectorXd& t_new) {
+                                             Eigen::MatrixXd& vals_old,
+                                             const Eigen::VectorXd& t_new) {
     assert(vals_old.rows() == 6);
 
     Eigen::MatrixXd vals_new(6, t_new.size());
@@ -635,11 +633,10 @@ Eigen::MatrixXd IrregularWaves::ResampleVals(const Eigen::VectorXd& t_old,
         vals_new.col(i) = spline(t_new_scaled[i]);
     }
 
-    //std::cout << "Old time vector:\n" << t_old << std::endl;
-    //std::cout << "Old values:\n" << vals_old << std::endl;
-    //std::cout << "New time vector:\n" << t_new << std::endl;
-    //std::cout << "New values:\n" << vals_new << std::endl;  // assuming new_vals is the output of the function
-
+    // std::cout << "Old time vector:\n" << t_old << std::endl;
+    // std::cout << "Old values:\n" << vals_old << std::endl;
+    // std::cout << "New time vector:\n" << t_new << std::endl;
+    // std::cout << "New values:\n" << vals_new << std::endl;  // assuming new_vals is the output of the function
 
     return vals_new;
 }
@@ -677,7 +674,8 @@ void IrregularWaves::CreateSpectrum() {
     spectrum_frequencies_ = Eigen::VectorXd::LinSpaced(1000, 0.001, 1.0);
 
     // Calculate the Pierson-Moskowitz Spectrum
-    spectral_densities_ = JONSWAPSpectrumHz(spectrum_frequencies_, wave_height_, wave_period_, peak_enhancement_factor_);
+    spectral_densities_ =
+        JONSWAPSpectrumHz(spectrum_frequencies_, wave_height_, wave_period_, peak_enhancement_factor_);
 
     // Open a file stream for writing
     std::ofstream outputFile("spectral_densities.txt");
@@ -777,18 +775,18 @@ double IrregularWaves::ExcitationConvolution(int body, int dof, double time) {
     double width = ex_irf_time_resampled_[body][1] - ex_irf_time_resampled_[body][0];
     // std::cout << "width=" << width << std::endl;
     for (size_t j = 0; j < ex_irf_time_resampled_[0].size(); ++j) {
-        double tau        = ex_irf_time_resampled_[0][j];
-        double t_tau      = time - tau;
-        
+        double tau   = ex_irf_time_resampled_[0][j];
+        double t_tau = time - tau;
+
         double ex_irf_val = ex_irf_resampled_[body](dof, j);
 
         if (0.0 < t_tau && t_tau < free_surface_elevation_.size() * width) {
             size_t eta_index = static_cast<size_t>(t_tau / width);
             double eta_val   = free_surface_elevation_[eta_index - 1];
 
-            //std::cout << "ex_irf_val = " << ex_irf_val << std::endl;
-            //std::cout << "eta_val = " << eta_val << std::endl;
-            //std::cout << "width = " << width << std::endl;
+            // std::cout << "ex_irf_val = " << ex_irf_val << std::endl;
+            // std::cout << "eta_val = " << eta_val << std::endl;
+            // std::cout << "width = " << width << std::endl;
 
             f_ex += ex_irf_val * eta_val * width;  // eta is wave elevation
         }
@@ -797,11 +795,12 @@ double IrregularWaves::ExcitationConvolution(int body, int dof, double time) {
     return f_ex;
 }
 
- void IrregularWaves::SetUpWaveMesh(std::string filename) {
-    mesh_file_name_             = filename;
+void IrregularWaves::SetUpWaveMesh(std::string filename) {
+    mesh_file_name_            = filename;
     int num_timesteps          = static_cast<int>(simulation_duration_ / simulation_dt_) + 1;
     Eigen::VectorXd time_index = Eigen::VectorXd::LinSpaced(num_timesteps, 0, simulation_duration_);
-    std::vector<std::array<double, 3>> free_surface_3d_pts = CreateFreeSurface3DPts(free_surface_elevation_, time_index);
+    std::vector<std::array<double, 3>> free_surface_3d_pts =
+        CreateFreeSurface3DPts(free_surface_elevation_, time_index);
     std::vector<std::array<size_t, 3>> free_surface_triangles = CreateFreeSurfaceTriangles(time_index.size());
 
     WriteFreeSurfaceMeshObj(free_surface_3d_pts, free_surface_triangles, mesh_file_name_);

--- a/src/wave_types.cpp
+++ b/src/wave_types.cpp
@@ -86,216 +86,6 @@ double RegularWave::GetExcitationPhaseInterp(int b, int i, int j, double freq_in
     return excitationPhase;
 }
 
-/////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-//// Irregular wave class definitions:
-// IrregularWave::IrregularWave() {
-//    num_bodies = 1;
-//}
-//
-// IrregularWave::IrregularWave(unsigned int num_b) {
-//    num_bodies = num_b;
-//}
-//
-// void IrregularWave::Initialize() {
-//    std::vector<Eigen::MatrixXd> ex_irf_old(num_bodies);
-//    std::vector<Eigen::VectorXd> ex_irf_time_old(num_bodies);
-//    for (int b = 0; b < num_bodies; b++) {
-//        ex_irf_old[b]      = GetExcitationIRF(b);
-//        ex_irf_time_old[b] = wave_info[b].excitation_irf_time;
-//    }
-//
-//    // resample excitation IRF time series
-//    // h5 file irf has different timestep, want to resample with interpolation (cubic spline?) once at start no
-//    // interpolation in convolution integral part
-//    // different one for each body it's 6x1x1000 so maybe switch to 2d reading
-//    ex_irf_resampled.resize(num_bodies);
-//    ex_irf_time_resampled.resize(num_bodies);
-//    for (int b = 0; b < num_bodies; b++) {  // function call (time_in, vals_in, &time_out, &vals_out)
-//        ex_irf_time_resampled[b] = ResampleTime(ex_irf_time_old[b], simulation_dt);
-//        ex_irf_resampled[b]      = ResampleVals(ex_irf_time_old[b], ex_irf_old[b], ex_irf_time_resampled[b]);
-//    }
-//
-//    CreateSpectrum();              // output in spectral_densities.txt
-//    CreateFreeSurfaceElevation();  // eta initialized in here, and output to eta.txt
-//}
-//
-// Eigen::MatrixXd IrregularWave::ResampleVals(const Eigen::VectorXd& t_old,
-//                                            Eigen::MatrixXd& vals_old,
-//                                            const Eigen::VectorXd& t_new) {
-//    assert(vals_old.rows() == 6);
-//
-//    Eigen::MatrixXd vals_new(6, t_new.size());
-//    // we need to scale t to be [0,1] for spline use
-//    // TODO: change this to accomodate variable dt instead of const dt
-//    Eigen::VectorXd t_old_scaled = Eigen::VectorXd::LinSpaced(t_old.size(), 0, 1);
-//    Eigen::VectorXd t_new_scaled = Eigen::VectorXd::LinSpaced(t_new.size(), 0, 1);
-//
-//    Eigen::Spline<double, 6> spline =
-//        Eigen::SplineFitting<Eigen::Spline<double, 6>>::Interpolate(vals_old, 3, t_old_scaled);
-//    for (int i = 0; i < t_new.rows(); i++) {
-//        vals_new.col(i) = spline(t_new_scaled[i]);
-//    }
-//
-//    return vals_new;
-//}
-//
-// Eigen::VectorXd IrregularWave::ResampleTime(const Eigen::VectorXd& t_old, const double dt_new) {
-//    double dt_old    = t_old[1] - t_old[0];
-//    int size_new     = static_cast<int>(ceil(t_old.size() * dt_old / dt_new));
-//    double t_initial = t_old[0];
-//    double t_final   = t_old[t_old.size() - 1];
-//    // t_0 and t_final should be the same in old/new versions, use new time step, which means a different number of
-//    // timesteps
-//    Eigen::VectorXd t_new = Eigen::VectorXd::LinSpaced(size_new, t_initial, t_final);
-//
-//    // print for testing
-//    int N_old = t_old.size() - 1;
-//    int N_new = t_new.size() - 1;
-//    //std::cout << "T_old = {t_i | i = 0 .. " << N_old << ", t_0 = " << t_old[0] << ", t_" << N_old << " = "
-//    //          << t_old[N_old] << "}\n"
-//    //          << "dt_old = " << dt_old << "\nT_new = {t_i | i = 0 .. " << N_new << ", t_0 = " << t_new[0] << ", t_"
-//    //          << N_new << " = " << t_new[N_new] << "}\n"
-//    //          << "dt_new = " << dt_new << std::endl;
-//
-//    return t_new;
-//}
-//
-// void IrregularWave::AddH5Data(std::vector<HydroData::IrregularWaveInfo>& irreg_h5_data,
-//                              HydroData::SimulationParameters& sim_data) {
-//    wave_info = irreg_h5_data;
-//    sim_data  = sim_data;
-//}
-//
-// Eigen::VectorXd IrregularWave::GetForceAtTime(double t) {
-//    unsigned int total_dofs = num_bodies * 6;
-//    Eigen::VectorXd f(total_dofs);
-//    // initialize the force here:
-//    // for now set f to all zeros
-//    for (int i = 0; i < total_dofs; i++) {
-//        f[i] = 0.0;
-//    }
-//    // see ComputeForceExcitation and convolution functions
-//
-//    // force_excitation.resize(total_dofs, 0.0);
-//
-//    for (int body = 0; body < num_bodies; body++) {
-//        // Loop through the DOFs
-//        for (int dof = 0; dof < 6; ++dof) {
-//            // Compute the convolution for the current DOF
-//            double f_dof          = ExcitationConvolution(body, dof, t);
-//            unsigned int b_offset = body * 6;
-//            f[b_offset + dof]     = f_dof;
-//        }
-//    }
-//    return f;
-//}
-//
-/////*******************************************************************************
-//// * IrregularWave::GetExcitationIRF()
-//// * returns the std::vector of excitation_irf_matrix from h5 file
-//// *******************************************************************************/
-////Eigen::MatrixXd IrregularWave::GetExcitationIRF(int b) const {
-////    return wave_info[b].excitation_irf_matrix;
-////}
-//
-// double IrregularWave::ExcitationConvolution(int body, int dof, double time) {
-//    double f_ex  = 0.0;
-//    double width = ex_irf_time_resampled[body][1] - ex_irf_time_resampled[body][0];
-//    //std::cout << "width=" << width << std::endl;
-//
-//    for (size_t j = 0; j < ex_irf_time_resampled[0].size(); ++j) {
-//        double tau        = ex_irf_time_resampled[0][j];
-//        double t_tau      = time - tau;
-//        double ex_irf_val = ex_irf_resampled[body](dof, j);
-//        if (0.0 < t_tau && t_tau < eta.size() * width) {
-//            size_t eta_index = static_cast<size_t>(t_tau / width);
-//            double eta_val   = eta[eta_index - 1];
-//            f_ex += ex_irf_val * eta_val * width;  // eta is wave elevation
-//        }
-//    }
-//
-//    return f_ex;
-//}
-//
-// Eigen::VectorXd IrregularWave::SetSpectrumFrequencies(double start, double end, int num_points) {
-//    Eigen::VectorXd result(num_points);
-//    double step = (end - start) / (num_points - 1);
-//
-//    for (int i = 0; i < num_points; ++i) {
-//        result[i] = start + i * step;
-//    }
-//
-//    spectrum_frequencies = result;
-//
-//    return result;
-//}
-//
-// void IrregularWave::CreateSpectrum() {
-//    // Define the frequency vector
-//    spectrum_frequencies = Eigen::VectorXd::LinSpaced(1000, 0.001, 1.0);
-//
-//    // Calculate the Pierson-Moskowitz Spectrum
-//    spectral_densities = PiersonMoskowitzSpectrumHz(spectrum_frequencies, wave_height, wave_period);
-//
-//    // Open a file stream for writing
-//    std::ofstream outputFile("spectral_densities.txt");
-//
-//    // Check if the file stream is open
-//    if (outputFile.is_open()) {
-//        // Write the spectral densities and their corresponding frequencies to the file
-//        for (size_t i = 0; i < spectral_densities.size(); ++i) {
-//            outputFile << spectrum_frequencies[i] << " : " << spectral_densities[i] << std::endl;
-//        }
-//
-//        // Close the file stream
-//        outputFile.close();
-//    } else {
-//        std::cerr << "Unable to open file for writing." << std::endl;
-//    }
-//}
-//
-// void IrregularWave::CreateFreeSurfaceElevation() {
-//    // Create a time index vector
-//    // UpdateNumTimesteps();
-//    int num_timesteps = static_cast<int>(simulation_duration / simulation_dt) + 1;
-//
-//    Eigen::VectorXd time_index = Eigen::VectorXd::LinSpaced(num_timesteps, 0, simulation_duration);
-//
-//    // Calculate the free surface elevation
-//    eta = FreeSurfaceElevation(spectrum_frequencies, spectral_densities, time_index, sim_data.water_depth);
-//
-//    // Apply ramp if ramp_duration is greater than 0
-//    if (ramp_duration > 0.0) {
-//        // UpdateRampTimesteps();
-//        int ramp_timesteps   = static_cast<int>(ramp_duration / simulation_dt) + 1;
-//        Eigen::VectorXd ramp = Eigen::VectorXd::LinSpaced(ramp_timesteps, 0.0, 1.0);
-//
-//        for (size_t i = 0; i < ramp.size(); ++i) {
-//            eta[i] *= ramp[i];
-//        }
-//    }
-//
-//    // Open a file stream for writing
-//    std::ofstream eta_output("eta.txt");
-//    // Check if the file stream is open
-//    if (eta_output.is_open()) {
-//        // Write the spectral densities and their corresponding frequencies to the file
-//        for (size_t i = 0; i < eta.size(); ++i) {
-//            eta_output << time_index[i] << " : " << eta[i] << std::endl;
-//        }
-//        // Close the file stream
-//        eta_output.close();
-//    } else {
-//        std::cerr << "Unable to open file for writing." << std::endl;
-//    }
-//
-//    // std::vector<std::array<double, 3>> free_surface_3d_pts    = CreateFreeSurface3DPts(eta, time_index);
-//    // std::vector<std::array<size_t, 3>> free_surface_triangles = CreateFreeSurfaceTriangles(time_index.size());
-//
-//    // WriteFreeSurfaceMeshObj(free_surface_3d_pts, free_surface_triangles, "fse_mesh.obj");
-//}
-
 std::vector<double> ComputeWaveNumbers(const std::vector<double>& omegas,
                                        double water_depth,
                                        double g           = 9.81,
@@ -376,16 +166,6 @@ std::vector<double> FreeSurfaceElevation(const Eigen::VectorXd& freqs_hz,
     return eta;
 }
 
-// void IrregularWave::SetUpWaveMesh(std::string filename) {
-//    mesh_file_name             = filename;
-//    int num_timesteps          = static_cast<int>(simulation_duration / simulation_dt) + 1;
-//    Eigen::VectorXd time_index = Eigen::VectorXd::LinSpaced(num_timesteps, 0, simulation_duration);
-//    std::vector<std::array<double, 3>> free_surface_3d_pts    = CreateFreeSurface3DPts(eta, time_index);
-//    std::vector<std::array<size_t, 3>> free_surface_triangles = CreateFreeSurfaceTriangles(time_index.size());
-//
-//    WriteFreeSurfaceMeshObj(free_surface_3d_pts, free_surface_triangles, mesh_file_name);
-//}
-
 std::vector<std::array<double, 3>> CreateFreeSurface3DPts(const std::vector<double>& eta,
                                                           const Eigen::VectorXd& t_vec) {
     std::vector<std::array<double, 3>> surface(t_vec.size() * 2);
@@ -451,26 +231,6 @@ void WriteFreeSurfaceMeshObj(const std::vector<std::array<double, 3>>& points,
     out.close();
 }
 
-// std::string IrregularWave::GetMeshFile() {
-//    return mesh_file_name;
-//}
-//
-// Eigen::Vector3<double> IrregularWave::GetWaveMeshVelocity() {
-//    return Eigen::Vector3d(1.0, 0, 0);
-//}
-
-// IrregularWaves::IrregularWaves(const std::string& eta_file_path, double wave_height, double wave_period)
-//    : eta_file_path(eta_file_path), wave_height(wave_height), wave_period(wave_period) {
-//    if (!eta_file_path.empty()) {
-//        ReadEtaFromFile();
-//        spectrumCreated = false;
-//    } else {
-//        CreateSpectrum();
-//        CreateFreeSurfaceElevation();
-//        spectrumCreated = true;
-//    }
-//}
-
 IrregularWaves::IrregularWaves(const IrregularWaveParams& params)
     : num_bodies_(params.num_bodies_),
       eta_file_path_(params.eta_file_path_),
@@ -499,20 +259,6 @@ IrregularWaves::IrregularWaves(const IrregularWaveParams& params)
 
     std::vector<Eigen::MatrixXd> ex_irf_old(num_bodies_);
     std::vector<Eigen::VectorXd> ex_irf_time_old(num_bodies_);
-
-    // for (unsigned int b = 0; b < num_bodies; b++) {
-    //    std::cout << "get excitation IRFs..." << std::endl;
-    //    ex_irf_old[b]      = GetExcitationIRF(b);
-    //    std::cout << "get excitation IRF time..." << std::endl;
-    //    ex_irf_time_old[b] = wave_info[b].excitation_irf_time;
-    //}
-
-    //// Resample excitation IRF time series
-    // std::cout << "resample IRFs..." << std::endl;
-    // for (unsigned int b = 0; b < num_bodies; b++) {
-    //    ex_irf_time_resampled[b] = ResampleTime(ex_irf_time_old[b], simulation_dt);
-    //    ex_irf_resampled[b]      = ResampleVals(ex_irf_time_old[b], ex_irf_old[b], ex_irf_time_resampled[b]);
-    //}
 
     std::cout << "IrregularWaves instantiated..." << std::endl;
 }
@@ -570,10 +316,6 @@ void IrregularWaves::ReadEtaFromFile() {
     }
 }
 
-/*******************************************************************************
- * IrregularWave::GetExcitationIRF()
- * returns the std::vector of excitation_irf_matrix from h5 file
- *******************************************************************************/
 Eigen::MatrixXd IrregularWaves::GetExcitationIRF(int b) const {
     return wave_info_[b].excitation_irf_matrix;
 }
@@ -581,13 +323,6 @@ Eigen::MatrixXd IrregularWaves::GetExcitationIRF(int b) const {
 void IrregularWaves::AddH5Data(std::vector<HydroData::IrregularWaveInfo>& irreg_h5_data,
                                HydroData::SimulationParameters& sim_data) {
     wave_info_ = irreg_h5_data;
-    sim_data   = sim_data;  // Note: This line seems to be redundant as mentioned before.
-
-    //// Add this loop to print the values of wave_info[b].excitation_irf_matrix for each body
-    // for (unsigned int b = 0; b < num_bodies; ++b) {
-    //    std::cout << "wave_info[" << b << "].excitation_irf_matrix:\n";
-    //    std::cout << wave_info[b].excitation_irf_matrix << std::endl;
-    //}
 
     InitializeIRFVectors();
 }
@@ -595,14 +330,9 @@ void IrregularWaves::AddH5Data(std::vector<HydroData::IrregularWaveInfo>& irreg_
 Eigen::VectorXd IrregularWaves::GetForceAtTime(double t) {
     unsigned int total_dofs = num_bodies_ * 6;
     Eigen::VectorXd f(total_dofs);
-    // initialize the force here:
-    // for now set f to all zeros
     for (int i = 0; i < total_dofs; i++) {
         f[i] = 0.0;
     }
-    // see ComputeForceExcitation and convolution functions
-
-    // force_excitation.resize(total_dofs, 0.0);
 
     for (int body = 0; body < num_bodies_; body++) {
         // Loop through the DOFs
@@ -619,33 +349,36 @@ Eigen::VectorXd IrregularWaves::GetForceAtTime(double t) {
 
 void IrregularWaves::ResampleIRF(double dt) {
     for (unsigned int b = 0; b < num_bodies_; b++) {
-        // 0) access arrays to modify at body index
         auto& time_array  = ex_irf_time_sampled_[b];
         auto& width_array = ex_irf_width_sampled_[b];
         auto& val_array   = ex_irf_sampled_[b];
-        // copy time array
+
+        // Copy time array
         auto time_array_old = time_array;
 
-        // 1) resample time
+        // 1) Resample time
         auto t0    = time_array_old[0];
         auto t1    = time_array_old[time_array_old.size() - 1];
         time_array = Eigen::VectorXd::LinSpaced(static_cast<int>(ceil((t1 - t0) / dt)), t0, t1);
 
-        // 2) resample width
+        // 2) Resample width
         CalculateWidthIRF();
 
-        // 3) resample values
+        // 3) Resample values
         assert(val_array.rows() == 6);
         Eigen::MatrixXd vals_new(6, time_array.size());
-        // we need to scale t to be [0,1] for spline use
+
+        // We need to scale t to be [0,1] for spline use
         Eigen::VectorXd t_old_scaled = Eigen::VectorXd::LinSpaced(time_array_old.size(), 0, 1);
         Eigen::VectorXd t_new_scaled = Eigen::VectorXd::LinSpaced(time_array.size(), 0, 1);
-        // use spline to get new values
+
+        // Use spline to get new values
         Eigen::Spline<double, 6> spline =
             Eigen::SplineFitting<Eigen::Spline<double, 6>>::Interpolate(val_array, 3, t_old_scaled);
         for (int i = 0; i < time_array.rows(); i++) {
             vals_new.col(i) = spline(t_new_scaled[i]);
         }
+
         val_array = vals_new;
     }
 }
@@ -655,7 +388,6 @@ void IrregularWaves::CalculateWidthIRF() {
         auto& time_array  = ex_irf_time_sampled_[b];
         auto& width_array = ex_irf_width_sampled_[b];
 
-        // 2) calculate width
         width_array.resize(time_array.size());
         for (int ii = 0; ii < width_array.size(); ii++) {
             width_array[ii] = 0.0;
@@ -747,7 +479,8 @@ void IrregularWaves::CreateFreeSurfaceElevation() {
     int num_timesteps = static_cast<int>(simulation_duration_ / simulation_dt_) + 1;
 
     auto time_array = Eigen::VectorXd::LinSpaced(num_timesteps, 0, simulation_duration_);
-    // save time array as a std::vector
+
+    // Save time array as a std::vector
     free_surface_time_sampled_.resize(time_array.size());
     Eigen::VectorXd::Map(&free_surface_time_sampled_[0], time_array.size()) = time_array;
 
@@ -768,6 +501,7 @@ void IrregularWaves::CreateFreeSurfaceElevation() {
 
     // Open a file stream for writing
     std::ofstream eta_output("eta.txt");
+
     // Check if the file stream is open
     if (eta_output.is_open()) {
         // Write the spectral densities and their corresponding frequencies to the file
@@ -782,7 +516,6 @@ void IrregularWaves::CreateFreeSurfaceElevation() {
 
     // std::vector<std::array<double, 3>> free_surface_3d_pts    = CreateFreeSurface3DPts(eta, time_index);
     // std::vector<std::array<size_t, 3>> free_surface_triangles = CreateFreeSurfaceTriangles(time_index.size());
-
     // WriteFreeSurfaceMeshObj(free_surface_3d_pts, free_surface_triangles, "fse_mesh.obj");
 }
 


### PR DESCRIPTION
This PR addresses part of #48 with the following features:
- Interpolate the free surface elevation value when it does not match the excitation force IRF sampling during the convolution
- Simplify resampling of the IRF for excitation force
- Precalculate width for IRF excitation convolution
- Do not resample IRF if `simulation_dt_ = 0.0` (but free surface needs a `simulation_dt > 0` anyway)