### PR TITLE
Fixes for wave kinematics

### DIFF
--- a/include/hydroc/wave_types.h
+++ b/include/hydroc/wave_types.h
@@ -165,6 +165,7 @@ class RegularWave : public WaveBase {
     double regular_wave_amplitude_;
     double regular_wave_omega_;
     double regular_wave_phase_ = 0.0;
+    bool wave_stretching_ = true;
 
     /**
      * @brief Initializes other member variables for timestep calculations later.

--- a/src/wave_types.cpp
+++ b/src/wave_types.cpp
@@ -11,6 +11,14 @@
 #include <iomanip>
 
 
+bool is_in_deep_water(double wavenumber, double water_depth) {
+    if (wavenumber * water_depth > 89.4) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 double GetEta(const Eigen::Vector3d& position,
               double time,
               double omega,
@@ -73,7 +81,7 @@ Eigen::Vector3d GetWaterVelocity(const Eigen::Vector3d& position,
 
     // get water velocity
     auto water_velocity = Eigen::Vector3d(0.0, 0.0, 0.0);
-    if (2 * M_PI / wavenumber > water_depth || wavenumber * water_depth > 500.0) {
+    if (is_in_deep_water(wavenumber, water_depth)) {
         // deep water
         water_velocity[0] =
             omega * amplitude * std::exp(wavenumber * z_pos) * cos(wavenumber * x_pos - omega * time + phase);
@@ -105,7 +113,7 @@ Eigen::Vector3d GetWaterAcceleration(const Eigen::Vector3d& position,
 
     // get water velocity
     auto water_acceleration = Eigen::Vector3d(0.0, 0.0, 0.0);
-    if (2 * M_PI / wavenumber > water_depth || wavenumber * water_depth > 500.0) {
+    if (is_in_deep_water(wavenumber, water_depth)) {
         // deep water
         water_acceleration[0] =
             omega * omega * amplitude * std::exp(wavenumber * z_pos) * sin(wavenumber * x_pos - omega * time + phase);

--- a/src/wave_types.cpp
+++ b/src/wave_types.cpp
@@ -19,6 +19,14 @@ bool is_in_deep_water(double wavenumber, double water_depth) {
     }
 }
 
+Eigen::Vector3d GetWheelerStretchedPosition(const Eigen::Vector3d& position, double eta, double water_depth, double mwl) {
+    // position relative to mean water level
+    auto z_pos = position.z() - mwl;
+    // Wheeler stretching
+    auto z_stretched = water_depth * (z_pos - eta) / (water_depth + eta);
+    return Eigen::Vector3d(position.x(), position.y(), z_stretched + mwl);
+}
+
 double GetEta(const Eigen::Vector3d& position,
               double time,
               double omega,
@@ -310,12 +318,7 @@ Eigen::Vector3d RegularWave::GetVelocity(const Eigen::Vector3d& position, double
     // apply wave stretching (if enabled)
     auto position_stretched = position;
     if (wave_stretching_) {
-        auto eta = GetElevation(position, time);
-        // position relative to mean water level
-        auto z_pos = position.z() - mwl_;
-        // Wheeler stretching
-        auto z_stretched = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
-        position_stretched[2] = z_stretched + mwl_;
+        position_stretched = GetWheelerStretchedPosition(position, GetElevation(position, time), water_depth_, mwl_);
     }
     return GetWaterVelocity(position_stretched, time, regular_wave_omega_, regular_wave_amplitude_, regular_wave_phase_,
                             wavenumber_, water_depth_, mwl_);
@@ -325,12 +328,7 @@ Eigen::Vector3d RegularWave::GetAcceleration(const Eigen::Vector3d& position, do
     // apply wave stretching (if enabled)
     auto position_stretched = position;
     if (wave_stretching_) {
-        auto eta = GetElevation(position, time);
-        // position relative to mean water level
-        auto z_pos = position.z() - mwl_;
-        // Wheeler stretching
-        auto z_stretched = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
-        position_stretched[2] = z_stretched + mwl_;
+        position_stretched = GetWheelerStretchedPosition(position, GetElevation(position, time), water_depth_, mwl_);
     }
     return GetWaterAcceleration(position_stretched, time, regular_wave_omega_, regular_wave_amplitude_, regular_wave_phase_,
                                 wavenumber_, water_depth_, mwl_);
@@ -544,13 +542,7 @@ Eigen::Vector3d IrregularWaves::GetVelocity(const Eigen::Vector3d& position, dou
     // apply wave stretching (if enabled)
     auto position_stretched = position;
     if (params_.wave_stretching_) {
-        auto eta = GetEtaIrregular(position, time, spectrum_frequencies_, spectral_densities_, spectral_widths_,
-                                   wave_phases_, wavenumbers_);
-        // position relative to mean water level
-        auto z_pos = position.z() - mwl_;
-        // Wheeler stretching
-        auto z_stretched = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
-        position_stretched[2] = z_stretched + mwl_;
+        position_stretched = GetWheelerStretchedPosition(position, GetElevation(position, time), water_depth_, mwl_);
     }
 
     return GetWaterVelocityIrregular(position_stretched, time, spectrum_frequencies_, spectral_densities_,
@@ -561,13 +553,7 @@ Eigen::Vector3d IrregularWaves::GetAcceleration(const Eigen::Vector3d& position,
     // apply wave stretching (if enabled)
     auto position_stretched = position;
     if (params_.wave_stretching_) {
-        auto eta = GetEtaIrregular(position, time, spectrum_frequencies_, spectral_densities_, spectral_widths_,
-                                   wave_phases_, wavenumbers_);
-        // position relative to mean water level
-        auto z_pos = position.z() - mwl_;
-        // Wheeler stretching
-        auto z_stretched = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
-        position_stretched[2] = z_stretched + mwl_;
+        position_stretched = GetWheelerStretchedPosition(position, GetElevation(position, time), water_depth_, mwl_);
     }
 
     return GetWaterAccelerationIrregular(position_stretched, time, spectrum_frequencies_, spectral_densities_,

--- a/src/wave_types.cpp
+++ b/src/wave_types.cpp
@@ -307,12 +307,32 @@ void RegularWave::AddH5Data(std::vector<HydroData::RegularWaveInfo>& reg_h5_data
 }
 
 Eigen::Vector3d RegularWave::GetVelocity(const Eigen::Vector3d& position, double time) {
-    return GetWaterVelocity(position, time, regular_wave_omega_, regular_wave_amplitude_, regular_wave_phase_,
+    // apply wave stretching (if enabled)
+    auto position_stretched = position;
+    if (wave_stretching_) {
+        auto eta = GetElevation(position, time);
+        // position relative to mean water level
+        auto z_pos = position.z() - mwl_;
+        // Wheeler stretching
+        auto z_stretched = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
+        position_stretched[2] = z_stretched + mwl_;
+    }
+    return GetWaterVelocity(position_stretched, time, regular_wave_omega_, regular_wave_amplitude_, regular_wave_phase_,
                             wavenumber_, water_depth_, mwl_);
 };
 
 Eigen::Vector3d RegularWave::GetAcceleration(const Eigen::Vector3d& position, double time) {
-    return GetWaterAcceleration(position, time, regular_wave_omega_, regular_wave_amplitude_, regular_wave_phase_,
+    // apply wave stretching (if enabled)
+    auto position_stretched = position;
+    if (wave_stretching_) {
+        auto eta = GetElevation(position, time);
+        // position relative to mean water level
+        auto z_pos = position.z() - mwl_;
+        // Wheeler stretching
+        auto z_stretched = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
+        position_stretched[2] = z_stretched + mwl_;
+    }
+    return GetWaterAcceleration(position_stretched, time, regular_wave_omega_, regular_wave_amplitude_, regular_wave_phase_,
                                 wavenumber_, water_depth_, mwl_);
 };
 
@@ -529,7 +549,8 @@ Eigen::Vector3d IrregularWaves::GetVelocity(const Eigen::Vector3d& position, dou
         // position relative to mean water level
         auto z_pos = position.z() - mwl_;
         // Wheeler stretching
-        position_stretched[2] = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
+        auto z_stretched = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
+        position_stretched[2] = z_stretched + mwl_;
     }
 
     return GetWaterVelocityIrregular(position_stretched, time, spectrum_frequencies_, spectral_densities_,
@@ -545,7 +566,8 @@ Eigen::Vector3d IrregularWaves::GetAcceleration(const Eigen::Vector3d& position,
         // position relative to mean water level
         auto z_pos = position.z() - mwl_;
         // Wheeler stretching
-        position_stretched[2] = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
+        auto z_stretched = water_depth_ * (z_pos - eta) / (water_depth_ + eta);
+        position_stretched[2] = z_stretched + mwl_;
     }
 
     return GetWaterAccelerationIrregular(position_stretched, time, spectrum_frequencies_, spectral_densities_,


### PR DESCRIPTION
This patch fixes the following issues:
- Add wave stretching option to regular waves
- Deep water check done with a common function (condition k*h>89.4 to be considered deep water)
- Wheeler wave stretching done with a common function, and corrected when mwl=/=0