### PR TITLE
Resolve MSVC warnings for cleaner builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,14 @@ target_link_libraries(HydroChronoGUI
         $<$<BOOL:${HYDROCHRONO_ENABLE_VSG}>:Chrono::Chrono_vsg>
 )
 
+# Suppress warnings from third-party Irrlicht headers on MSVC.
+# The Irrlicht headers trigger C4458 warnings (x/y hiding member) that we cannot fix.
+# Use /external:I to treat Irrlicht includes as external headers with reduced warning level.
+if(MSVC AND HYDROCHRONO_ENABLE_IRRLICHT AND DEFINED Irrlicht_ROOT)
+    target_include_directories(HydroChronoGUI SYSTEM PUBLIC "${Irrlicht_ROOT}/include")
+    target_compile_options(HydroChronoGUI PRIVATE /external:anglebrackets /external:W0)
+endif()
+
 # ===============================================================================
 # ------- Auxiliary Targets (app, tests, demos) ---------------------------------
 # ===============================================================================

--- a/demos/DeepCWind/demo_DeepCWind_decay.cpp
+++ b/demos/DeepCWind/demo_DeepCWind_decay.cpp
@@ -137,7 +137,7 @@ int main(int argc, char* argv[]) {
         outputFile.open("./results/DeepCWind_decay.txt");
         outputFile << std::left << std::setw(10) << "Time (s)" << std::right << std::setw(16) << "Base Surge (m)"
                    << std::right << std::setw(16) << "Base Pitch (radians)" << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(16) << std::setprecision(8) << std::fixed << base_surge[i]
                        << std::right << std::setw(16) << std::setprecision(8) << std::fixed << base_pitch[i]

--- a/demos/f3of/demo_F3OF_DT1.cpp
+++ b/demos/f3of/demo_F3OF_DT1.cpp
@@ -202,7 +202,7 @@ int main(int argc, char* argv[]) {
                    << std::right << std::setw(16) << "Base Pitch (radians)" << std::right << std::setw(16)
                    << "Flap Fore Pitch (radians)" << std::right << std::setw(16) << "Flap Aft Pitch (radians)"
                    << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(16) << std::setprecision(4) << std::fixed << base_surge[i]
                        << std::right << std::setw(16) << std::setprecision(4) << std::fixed << base_pitch[i]

--- a/demos/f3of/demo_F3OF_DT2.cpp
+++ b/demos/f3of/demo_F3OF_DT2.cpp
@@ -208,7 +208,7 @@ int main(int argc, char* argv[]) {
                    << std::right << std::setw(16) << "Base Pitch (radians)" << std::right << std::setw(16)
                    << "Flap Fore Pitch (radians)" << std::right << std::setw(16) << "Flap Aft Pitch (radians)"
                    << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(16) << std::setprecision(4) << std::fixed << base_surge[i]
                        << std::right << std::setw(16) << std::setprecision(4) << std::fixed << base_pitch[i]

--- a/demos/f3of/demo_F3OF_DT3.cpp
+++ b/demos/f3of/demo_F3OF_DT3.cpp
@@ -203,7 +203,7 @@ int main(int argc, char* argv[]) {
                    << std::right << std::setw(16) << "Base Pitch (radians)" << std::right << std::setw(16)
                    << "Flap Fore Pitch (radians)" << std::right << std::setw(16) << "Flap Aft Pitch (radians)"
                    << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(16) << std::setprecision(4) << std::fixed << base_surge[i]
                        << std::right << std::setw(16) << std::setprecision(4) << std::fixed << base_pitch[i]

--- a/demos/oswec/demo_oswec_decay.cpp
+++ b/demos/oswec/demo_oswec_decay.cpp
@@ -228,7 +228,7 @@ int main(int argc, char* argv[]) {
         outputFile << std::left << std::setw(10) << "Time (s)" << std::right << std::setw(16)
                    << "Flap Rotation y (radians)" << std::right << std::setw(16) << "Flap Rotation y (degrees)"
                    << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(16) << std::setprecision(4) << std::fixed << flap_rot[i] << std::right
                        << std::setw(16) << std::setprecision(4) << std::fixed << flap_rot[i] * 360.0 / 6.28

--- a/demos/oswec/demo_oswec_reg_waves.cpp
+++ b/demos/oswec/demo_oswec_reg_waves.cpp
@@ -262,7 +262,7 @@ int main(int argc, char* argv[]) {
             outputFile << std::left << std::setw(10) << "Time (s)" << std::right << std::setw(12)
                        << "Pitch (rads)"
                        << std::endl;
-            for (int i = 0; i < time_vector.size(); ++i)
+            for (size_t i = 0; i < time_vector.size(); ++i)
                 outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                            << std::right << std::setw(12) << std::setprecision(4) << std::fixed << flap_rot[i]
                            << std::endl;

--- a/demos/rm3/demo_rm3_decay.cpp
+++ b/demos/rm3/demo_rm3_decay.cpp
@@ -166,7 +166,7 @@ int main(int argc, char* argv[]) {
         std::ofstream outputFile(out_dir + "/decay.txt");
         outputFile << std::left << std::setw(10) << "Time (s)" << std::right << std::setw(16) << "Float Heave (m)"
                    << std::right << std::setw(16) << "Plate Heave (m)" << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(16) << std::setprecision(8) << std::fixed << float_heave_position[i]
                        << std::right << std::setw(16) << std::setprecision(8) << std::fixed << plate_heave_position[i]

--- a/demos/rm3/demo_rm3_reg_waves.cpp
+++ b/demos/rm3/demo_rm3_reg_waves.cpp
@@ -180,7 +180,7 @@ int main(int argc, char* argv[]) {
         outputFile << std::left << std::setw(10) << "Time (s)" << std::right << std::setw(16) << "Float Heave (m)"
                    << std::right << std::setw(16) << "Plate Heave (m)" << std::right << std::setw(16)
                    << "Float Drift (x) (m)" << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(16) << std::setprecision(4) << std::fixed << float_heave_position[i]
                        << std::right << std::setw(16) << std::setprecision(4) << std::fixed << plate_heave_position[i]

--- a/demos/sphere/demo_sphere_decay.cpp
+++ b/demos/sphere/demo_sphere_decay.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[]) {
                    //<< std::right << std::setw(18) << "Heave Vel (m/s)"
                    //<< std::right << std::setw(18) << "Heave Force (N)"
                    << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(12) << std::setprecision(6) << std::fixed << time_vector[i]
                        << std::right << std::setw(12) << std::setprecision(6) << std::fixed << heave_position[i]
                        << std::endl;

--- a/demos/sphere/demo_sphere_irreg_waves.cpp
+++ b/demos/sphere/demo_sphere_irreg_waves.cpp
@@ -87,9 +87,8 @@ int main(int argc, char* argv[]) {
     prismatic->Initialize(sphereBody, ground, false, ChFramed(ChVector3d(0, 0, -2)), ChFramed(ChVector3d(0, 0, -5)));
     system.AddLink(prismatic);
 
-    // create the spring between body_1 and ground. The spring end points are
+    // Create the spring between body_1 and ground. The spring end points are
     // specified in the body relative frames.
-    double rest_length  = 3.0;
     double spring_coef  = 0.0;
     double damping_coef = 0.0;
     auto spring_1       = chrono_types::make_shared<ChLinkTSDA>();
@@ -197,7 +196,7 @@ int main(int argc, char* argv[]) {
                    //<< std::right << std::setw(18) << "Heave Vel (m/s)"
                    //<< std::right << std::setw(18) << "Heave Force (N)"
                    << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(12) << std::setprecision(4) << std::fixed << heave_position[i]
                        << std::endl;

--- a/demos/sphere/demo_sphere_irreg_waves_eta_import.cpp
+++ b/demos/sphere/demo_sphere_irreg_waves_eta_import.cpp
@@ -89,7 +89,6 @@ int main(int argc, char* argv[]) {
 
     // Create the spring between body_1 and ground. The spring end points are
     // specified in the body relative frames.
-    double rest_length  = 3.0;
     double spring_coef  = 0.0;
     double damping_coef = 0.0;
     auto spring_1       = chrono_types::make_shared<ChLinkTSDA>();
@@ -207,7 +206,7 @@ int main(int argc, char* argv[]) {
                    //<< std::right << std::setw(18) << "Heave Vel (m/s)"
                    //<< std::right << std::setw(18) << "Heave Force (N)"
                    << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(12) << std::setprecision(4) << std::fixed << heave_position[i]
                        << std::endl;

--- a/demos/sphere/demo_sphere_reg_waves.cpp
+++ b/demos/sphere/demo_sphere_reg_waves.cpp
@@ -103,13 +103,12 @@ int main(int argc, char* argv[]) {
 
         // Create the spring between body_1 and ground. The spring end points are
         // specified in the body relative frames.
-        double rest_length  = 3.0;
         double spring_coef  = 0.0;
         double damping_coef = task10_damping_coeffs[reg_wave_num - 1];
         auto spring_1       = chrono_types::make_shared<ChLinkTSDA>();
         spring_1->Initialize(sphereBody, ground, false, ChVector3d(0, 0, -2),
                              ChVector3d(0, 0, -5));  // false means positions are in global frame
-        // spring_1->SetRestLength(rest_length); // if not set, the rest length is calculated from initial position
+        // Note: rest length is calculated from initial position when not explicitly set
         spring_1->SetSpringCoefficient(spring_coef);
         spring_1->SetDampingCoefficient(damping_coef);
         system.AddLink(spring_1);
@@ -169,7 +168,7 @@ int main(int argc, char* argv[]) {
                        //<< std::right << std::setw(18) << "Heave Vel (m/s)"
                        //<< std::right << std::setw(18) << "Heave Force (N)"
                        << std::endl;
-            for (int i = 0; i < time_vector.size(); ++i)
+            for (size_t i = 0; i < time_vector.size(); ++i)
                 outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                            << std::right << std::setw(12) << std::setprecision(4) << std::fixed << heave_position[i]
                            << std::endl;

--- a/demos/sphere/sphere_irreg_waves.cpp
+++ b/demos/sphere/sphere_irreg_waves.cpp
@@ -126,7 +126,6 @@ int main(int argc, char* argv[]) {
 
     // Create the spring between body_1 and ground. The spring end points are
     // specified in the body relative frames.
-    double rest_length  = 3.0;
     double spring_coef  = 0.0;
     double damping_coef = 0.0;
     auto spring_1       = chrono_types::make_shared<ChLinkTSDA>();
@@ -297,7 +296,7 @@ int main(int argc, char* argv[]) {
                    //<< std::right << std::setw(18) << "Heave Vel (m/s)"
                    //<< std::right << std::setw(18) << "Heave Force (N)"
                    << std::endl;
-        for (int i = 0; i < time_vector.size(); ++i)
+        for (size_t i = 0; i < time_vector.size(); ++i)
             outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                        << std::right << std::setw(12) << std::setprecision(4) << std::fixed << heave_position[i]
                        << std::endl;

--- a/include/hydroc/logging.h
+++ b/include/hydroc/logging.h
@@ -21,11 +21,9 @@
 #include <vector>
 
 // Version information - these may be provided by the build system
+// Note: Use HYDROCHRONO_* prefixed macros to avoid conflicts with Chrono's ChVersion.h
 #ifndef HYDROCHRONO_VERSION
     #define HYDROCHRONO_VERSION "unknown"
-#endif
-#ifndef CHRONO_VERSION
-    #define CHRONO_VERSION "unknown"
 #endif
 #ifndef HYDROCHRONO_BUILD_TYPE
     #define HYDROCHRONO_BUILD_TYPE "unknown"

--- a/src/hydro/config/setup_from_yaml.cpp
+++ b/src/hydro/config/setup_from_yaml.cpp
@@ -163,7 +163,8 @@ std::unique_ptr<HydroSystem> SetupHydroFromYAML(
     }
     
     // Create wave object from settings (system-wide, not per-body)
-    auto wave = CreateWaveFromSettings(hydro_data.waves, matched_bodies.size(), 
+    auto wave = CreateWaveFromSettings(hydro_data.waves, 
+                                      static_cast<unsigned int>(matched_bodies.size()), 
                                       timestep, sim_duration, ramp_duration);
     
     // Create and initialize HydroSystem (multibody: all matched bodies passed in)

--- a/src/hydro/force_components/radiation_component.cpp
+++ b/src/hydro/force_components/radiation_component.cpp
@@ -84,7 +84,6 @@ double RadiationComponent::GetRIRFval(int row, int col, int st) {
     }
 
     int body_index = row / kDofPerBody;
-    int col_dof    = col % kDofPerBody;
     int row_dof    = row % kDofPerBody;
 
     if (convolution_mode_ == RadiationConvolutionMode::TaperedDirect) {

--- a/src/hydro/hydro_system.cpp
+++ b/src/hydro/hydro_system.cpp
@@ -232,7 +232,7 @@ HydroSystem::HydroSystem(std::vector<std::shared_ptr<ChBody>> user_bodies,
                      std::string h5_file_name,
                      std::shared_ptr<WaveBase> waves)
     : bodies_(user_bodies),
-      num_bodies_(bodies_.size()),
+      num_bodies_(static_cast<int>(bodies_.size())),
       file_info_(H5FileInfo(h5_file_name, num_bodies_).ReadH5Data()),
       hydro_forces_(nullptr),
       chrono_coupler_(nullptr),
@@ -244,7 +244,7 @@ HydroSystem::HydroSystem(std::vector<std::shared_ptr<ChBody>> user_bodies,
     rirf_time_vector = file_info_.GetRIRFTimeVector();
     // width array
     rirf_width_vector.resize(rirf_time_vector.size());
-    for (int ii = 0; ii < rirf_width_vector.size(); ii++) {
+    for (Eigen::Index ii = 0; ii < rirf_width_vector.size(); ii++) {
         rirf_width_vector[ii] = 0.0;
         if (ii < rirf_time_vector.size() - 1) {
             rirf_width_vector[ii] += 0.5 * abs(rirf_time_vector[ii + 1] - rirf_time_vector[ii]);
@@ -547,9 +547,8 @@ void HydroSystem::EnsureHydroForcesAndCoupler() {
 // CoordinateFuncForBody(). The main force path now goes through HydroForces.
 std::vector<double> HydroSystem::ComputeForceRadiationDampingConv() {
     auto __t0 = std::chrono::steady_clock::now();
-    const int total_dofs = kDofPerBody * num_bodies_;
 
-    assert(total_dofs > 0);
+    assert(kDofPerBody * num_bodies_ > 0);
 
     // Ensure radiation component exists with current settings
     EnsureRadiationComponent();
@@ -603,7 +602,6 @@ double HydroSystem::GetRIRFval(int row, int col, int st) {
     }
 
     int body_index = row / kDofPerBody;
-    int col_dof    = col % kDofPerBody;
     int row_dof    = row % kDofPerBody;
 
     if (convolution_mode_ == hydrochrono::hydro::RadiationConvolutionMode::TaperedDirect) {

--- a/src/hydro/io/h5_reader.cpp
+++ b/src/hydro/io/h5_reader.cpp
@@ -240,7 +240,7 @@ void H5FileInfo::Init1D(H5::H5File& file, std::string data_name, Eigen::VectorXd
     // read file info into current_pos
     dataset.read(temp, H5::PredType::NATIVE_DOUBLE, mspace1, filespace);
     var.resize(dims[0] * dims[1]);
-    for (int i = 0; i < dims[0] * dims[1]; i++) {
+    for (Eigen::Index i = 0; i < static_cast<Eigen::Index>(dims[0] * dims[1]); i++) {
         var[i] = temp[i];
     }
     dataset.close();
@@ -261,9 +261,9 @@ void H5FileInfo::Init2D(H5::H5File& file, std::string data_name, Eigen::MatrixXd
     dataset.read(temp, H5::PredType::NATIVE_DOUBLE, mspace, filespace);
     // set var here
     var.resize(dims[0], dims[1]);
-    for (int i = 0; i < dims[0]; i++) {
-        for (int j = 0; j < dims[1]; j++) {
-            var(i, j) = temp[i * dims[1] + j];
+    for (Eigen::Index i = 0; i < static_cast<Eigen::Index>(dims[0]); i++) {
+        for (Eigen::Index j = 0; j < static_cast<Eigen::Index>(dims[1]); j++) {
+            var(i, j) = temp[static_cast<hsize_t>(i) * dims[1] + static_cast<hsize_t>(j)];
         }
     }
     dataset.close();
@@ -284,12 +284,12 @@ void H5FileInfo::Init3D(H5::H5File& file, std::string data_name, Eigen::Tensor<d
     // read file info into data_out, a 2d array
     dataset.read(temp, H5::PredType::NATIVE_DOUBLE, mspace, filespace);
     // set var here
-    var.resize((int64_t)dims[0], (int64_t)dims[1], (int64_t)dims[2]);
-    for (int i = 0; i < dims[0]; i++) {
-        for (int j = 0; j < dims[1]; j++) {
-            for (int k = 0; k < dims[2]; k++) {
-                int index    = k + dims[2] * (j + i * dims[1]);
-                var(i, j, k) = temp[index];
+    var.resize(static_cast<Eigen::Index>(dims[0]), static_cast<Eigen::Index>(dims[1]), static_cast<Eigen::Index>(dims[2]));
+    for (Eigen::Index i = 0; i < static_cast<Eigen::Index>(dims[0]); i++) {
+        for (Eigen::Index j = 0; j < static_cast<Eigen::Index>(dims[1]); j++) {
+            for (Eigen::Index k = 0; k < static_cast<Eigen::Index>(dims[2]); k++) {
+                hsize_t index = static_cast<hsize_t>(k) + dims[2] * (static_cast<hsize_t>(j) + static_cast<hsize_t>(i) * dims[1]);
+                var(i, j, k)  = temp[index];
             }
         }
     }
@@ -331,11 +331,11 @@ Eigen::VectorXd HydroData::GetRIRFTimeVector() const {
     // check if all time vectors are the same within tolerance
     auto& rirf_time_vector = body_data_[0].rirf_time_vector;
     for (size_t ii = 1; ii < body_data_.size(); ii++) {
-        for (size_t jj = 0; jj < body_data_[ii].rirf_time_vector.size(); jj++) {
+        for (Eigen::Index jj = 0; jj < body_data_[ii].rirf_time_vector.size(); jj++) {
             if (abs(body_data_[ii].rirf_time_vector[jj] - rirf_time_vector[jj]) > tol) {
                 throw std::runtime_error(
                     "RIRF time vectors have to be exactly the same for all bodies. Difference found in body " +
-                    std::to_string(jj) + " at time index " + std::to_string(jj) + ".");
+                    std::to_string(ii) + " at time index " + std::to_string(jj) + ".");
             }
         }
     }

--- a/src/hydro/io/simulation_export.cpp
+++ b/src/hydro/io/simulation_export.cpp
@@ -956,10 +956,7 @@ void SimulationExporter::Finalize() {
             gj.WriteDataset("reaction2_torque", j.react_torque_b2, d2_n3);
         }
     }
-    // Final succinct info line in Quiet mode
-    int bodies = static_cast<int>(impl_->bodies.size());
-    int dampers = static_cast<int>(impl_->tsdas.size() + impl_->rsdas.size());
-    int samples = static_cast<int>(impl_->time.size());
+
     // meta/run runtime details (if provided via options)
     {
         auto g_run = impl_->writer.RequireGroup("/meta/run");

--- a/src/hydro/logging/logger_backend.cpp
+++ b/src/hydro/logging/logger_backend.cpp
@@ -23,13 +23,14 @@
 
 // Version information - these should be defined by the build system
 #ifndef HYDROCHRONO_VERSION
-    constexpr const char* HYDROCHRONO_VERSION = "unknown";
-#endif
-#ifndef CHRONO_VERSION
-    constexpr const char* CHRONO_VERSION = "unknown";
+    #define HYDROCHRONO_VERSION "unknown"
 #endif
 #ifndef HYDROCHRONO_BUILD_TYPE
-    constexpr const char* HYDROCHRONO_BUILD_TYPE = "unknown";
+    #define HYDROCHRONO_BUILD_TYPE "unknown"
+#endif
+// CHRONO_VERSION may be defined by Chrono headers or CMake; provide fallback
+#ifndef CHRONO_VERSION
+    #define CHRONO_VERSION "unknown"
 #endif
 
 namespace hydroc {

--- a/src/hydro/runner/run_from_yaml.cpp
+++ b/src/hydro/runner/run_from_yaml.cpp
@@ -381,7 +381,9 @@ int RunHydroChronoFromYAML(int argc, char* argv[]) {
         log_cfg.console_level = debug_mode ? hydroc::LogLevel::Debug
                                            : hydroc::LogLevel::Info;
         log_cfg.file_level = hydroc::LogLevel::Debug;
-        hydroc::Initialize(log_cfg);
+        if (!hydroc::Initialize(log_cfg)) {
+            std::cerr << "Warning: Failed to initialize logging system\n";
+        }
         hydroc::cli::ShowBanner();
 
         // ---------------------------------------------------------------------

--- a/src/hydro/waves/irregular_wave.cpp
+++ b/src/hydro/waves/irregular_wave.cpp
@@ -65,7 +65,7 @@ std::vector<double> IrregularWaves::GetFreeSurfaceTime() const {
 
 std::vector<double> IrregularWaves::GetFrequenciesHz() const {
     std::vector<double> out(spectrum_frequencies_.size());
-    for (int i = 0; i < spectrum_frequencies_.size(); ++i) {
+    for (Eigen::Index i = 0; i < spectrum_frequencies_.size(); ++i) {
         out[i] = spectrum_frequencies_[i];
     }
     return out;
@@ -148,11 +148,11 @@ double IrregularWaves::GetElevation(const Eigen::Vector3d& position, double time
 Eigen::VectorXd IrregularWaves::GetForceAtTime(double t) {
     unsigned int total_dofs = params_.num_bodies_ * 6;
     Eigen::VectorXd f(total_dofs);
-    for (int i = 0; i < total_dofs; i++) {
+    for (unsigned int i = 0; i < total_dofs; i++) {
         f[i] = 0.0;
     }
 
-    for (int body = 0; body < params_.num_bodies_; body++) {
+    for (unsigned int body = 0; body < params_.num_bodies_; body++) {
         for (int dof = 0; dof < 6; ++dof) {
             double f_dof          = ExcitationConvolution(body, dof, t);
             unsigned int b_offset = body * 6;
@@ -226,7 +226,7 @@ void IrregularWaves::CreateSpectrum() {
 void IrregularWaves::CreateFreeSurfaceElevation() {
     double t_irf_min = 0.0;
     double t_irf_max = 0.0;
-    for (auto ii = 0; ii < ex_irf_time_sampled_.size(); ii++) {
+    for (size_t ii = 0; ii < ex_irf_time_sampled_.size(); ii++) {
         if (ex_irf_time_sampled_[ii][0] < t_irf_min) {
             t_irf_min = ex_irf_time_sampled_[ii][0];
         }
@@ -246,7 +246,7 @@ void IrregularWaves::CreateFreeSurfaceElevation() {
 
     free_surface_time_sampled_.resize(time_array.size());
     Eigen::VectorXd::Map(&free_surface_time_sampled_[0], time_array.size()) = time_array;
-    for (int ii = 0; ii < free_surface_time_sampled_.size(); ii++) {
+    for (size_t ii = 0; ii < free_surface_time_sampled_.size(); ii++) {
         free_surface_time_sampled_[ii] += -t_irf_max;
     }
 
@@ -276,9 +276,9 @@ void IrregularWaves::CreateFreeSurfaceElevation() {
 
 void IrregularWaves::ResampleIRF(double dt) {
     for (unsigned int b = 0; b < params_.num_bodies_; b++) {
-        auto& time_array  = ex_irf_time_sampled_[b];
-        auto& width_array = ex_irf_width_sampled_[b];
-        auto& val_array   = ex_irf_sampled_[b];
+        auto& time_array = ex_irf_time_sampled_[b];
+        // Note: width_array is recalculated by CalculateWidthIRF() below
+        auto& val_array  = ex_irf_sampled_[b];
 
         auto time_array_old = time_array;
 
@@ -320,17 +320,17 @@ double IrregularWaves::ExcitationConvolution(int body, int dof, double time) {
 
     auto tmin = free_surface_time_sampled_.front();
     auto tmax = free_surface_time_sampled_.back();
-    double t_tau = time - irf_time_array[0];
-    int idx      = 0;
-    if (t_tau <= tmin) {
+    double t_tau_init = time - irf_time_array[0];
+    int idx           = 0;
+    if (t_tau_init <= tmin) {
         idx = 0;
-    } else if (t_tau >= tmax) {
+    } else if (t_tau_init >= tmax) {
         idx = static_cast<int>(free_surface_time_sampled_.size()) - 2;
     } else {
-        idx = get_lower_index(t_tau, free_surface_time_sampled_);
+        idx = static_cast<int>(get_lower_index(t_tau_init, free_surface_time_sampled_));
     }
 
-    for (size_t j = 0; j < irf_time_array.size(); ++j) {
+    for (Eigen::Index j = 0; j < irf_time_array.size(); ++j) {
         double tau   = irf_time_array[j];
         double t_tau = time - tau;
         if (tmin <= t_tau && t_tau <= tmax) {

--- a/src/hydro/waves/regular_wave.cpp
+++ b/src/hydro/waves/regular_wave.cpp
@@ -32,9 +32,9 @@ void RegularWave::AddH5Data(std::vector<HydroData::RegularWaveInfo>& reg_h5_data
 
     double wave_omega_delta = GetOmegaDelta();
     double freq_index_des   = (regular_wave_omega_ / wave_omega_delta) - 1;
-    for (int b = 0; b < num_bodies_; b++) {
+    for (unsigned int b = 0; b < num_bodies_; b++) {
         for (int rowEx = 0; rowEx < 6; rowEx++) {
-            int body_offset = 6 * b;
+            unsigned int body_offset = 6 * b;
             excitation_force_mag_[body_offset + rowEx]   = GetExcitationMagInterp(b, rowEx, 0, freq_index_des);
             excitation_force_phase_[body_offset + rowEx] = GetExcitationPhaseInterp(b, rowEx, 0, freq_index_des);
         }
@@ -78,8 +78,8 @@ double RegularWave::GetElevation(const Eigen::Vector3d& position, double time) {
 Eigen::VectorXd RegularWave::GetForceAtTime(double t) {
     unsigned int dof = num_bodies_ * 6;
     Eigen::VectorXd f(dof);
-    for (int b = 0; b < num_bodies_; b++) {
-        int body_offset = 6 * b;
+    for (unsigned int b = 0; b < num_bodies_; b++) {
+        unsigned int body_offset = 6 * b;
         for (int rowEx = 0; rowEx < 6; rowEx++) {
             f[body_offset + rowEx] = excitation_force_mag_[body_offset + rowEx] * regular_wave_amplitude_ *
                                      std::cos(regular_wave_omega_ * t + excitation_force_phase_[rowEx]);

--- a/tests/regression/f3of/test_f3of_dt1.cpp
+++ b/tests/regression/f3of/test_f3of_dt1.cpp
@@ -199,7 +199,7 @@ int main(int argc, char* argv[]) {
             outputFile
                 << "Time (s)    Base Surge (m)Base Pitch (radians)Flap Fore Pitch (radians)Flap Aft Pitch (radians)"
                 << std::endl;
-            for (int i = 0; i < time_vector.size(); i++) {
+            for (size_t i = 0; i < time_vector.size(); i++) {
                 outputFile << std::fixed << std::setprecision(4) << time_vector[i] << "                "
                            << base_surge[i] << "         " << base_pitch[i] << "         " << fore_pitch[i]
                            << "          " << aft_pitch[i] << std::endl;

--- a/tests/regression/f3of/test_f3of_dt2.cpp
+++ b/tests/regression/f3of/test_f3of_dt2.cpp
@@ -211,7 +211,7 @@ int main(int argc, char* argv[]) {
             outputFile
                 << "Time (s)    Base Surge (m)Base Pitch (radians)Flap Fore Pitch (radians)Flap Aft Pitch (radians)"
                 << std::endl;
-            for (int i = 0; i < time_vector.size(); i++) {
+            for (size_t i = 0; i < time_vector.size(); i++) {
                 outputFile << std::fixed << std::setprecision(4) << time_vector[i] << "                "
                            << base_surge[i] << "         " << base_pitch[i] << "         " << fore_pitch[i]
                            << "          " << aft_pitch[i] << std::endl;

--- a/tests/regression/f3of/test_f3of_dt3.cpp
+++ b/tests/regression/f3of/test_f3of_dt3.cpp
@@ -212,7 +212,7 @@ int main(int argc, char* argv[]) {
                        << std::right << std::setw(16) << "Base Pitch (radians)" << std::right << std::setw(16)
                        << "Flap Fore Pitch (radians)" << std::right << std::setw(16) << "Flap Aft Pitch (radians)"
                        << std::endl;
-            for (int i = 0; i < time_vector.size(); ++i)
+            for (size_t i = 0; i < time_vector.size(); ++i)
                 outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                            << std::right << std::setw(16) << std::setprecision(4) << std::fixed << base_surge[i]
                            << std::right << std::setw(16) << std::setprecision(4) << std::fixed << base_pitch[i]

--- a/tests/regression/oswec/test_oswec_decay.cpp
+++ b/tests/regression/oswec/test_oswec_decay.cpp
@@ -249,7 +249,7 @@ int main(int argc, char* argv[]) {
             outputFile << std::left << std::setw(10) << "Time (s)" << std::right << std::setw(16)
                        << "Flap Rotation y (radians)" << std::right << std::setw(16) << "Flap Rotation y (degrees)"
                        << std::endl;
-            for (int i = 0; i < time_vector.size(); ++i)
+            for (size_t i = 0; i < time_vector.size(); ++i)
                 outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                            << std::right << std::setw(16) << std::setprecision(4) << std::fixed << flap_rot[i]
                            << std::right << std::setw(16) << std::setprecision(4) << std::fixed

--- a/tests/regression/oswec/test_oswec_reg_waves.cpp
+++ b/tests/regression/oswec/test_oswec_reg_waves.cpp
@@ -256,7 +256,7 @@ int main(int argc, char* argv[]) {
                 outputFile << "Wave omega (rad/s): \t" << my_hydro_inputs->regular_wave_omega_ << "\n";
                 outputFile << std::left << std::setw(10) << "Time (s)" << std::right << std::setw(12) << "Pitch (rads)"
                            << std::endl;
-                for (int i = 0; i < time_vector.size(); ++i)
+                for (size_t i = 0; i < time_vector.size(); ++i)
                     outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                                << std::right << std::setw(12) << std::setprecision(4) << std::fixed << flap_rot[i]
                                << std::endl;

--- a/tests/regression/rm3/test_rm3_decay.cpp
+++ b/tests/regression/rm3/test_rm3_decay.cpp
@@ -172,7 +172,7 @@ int main(int argc, char* argv[]) {
         if (outputFile.is_open()) {
             outputFile << std::left << std::setw(10) << "Time (s)" << std::right << std::setw(16) << "Float Heave (m)"
                        << std::right << std::setw(16) << "Plate Heave (m)" << std::endl;
-            for (int i = 0; i < time_vector.size(); ++i)
+            for (size_t i = 0; i < time_vector.size(); ++i)
                 outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                            << std::right << std::setw(16) << std::setprecision(8) << std::fixed
                            << float_heave_position[i] << std::right << std::setw(16) << std::setprecision(8)

--- a/tests/regression/rm3/test_rm3_reg_waves.cpp
+++ b/tests/regression/rm3/test_rm3_reg_waves.cpp
@@ -206,7 +206,7 @@ int main(int argc, char* argv[]) {
             outputFile << std::left << std::setw(10) << "Time (s)" << std::right << std::setw(16) << "Float Heave (m)"
                        << std::right << std::setw(16) << "Plate Heave (m)" << std::right << std::setw(16)
                        << "Float Drift (x) (m)" << std::endl;
-            for (int i = 0; i < time_vector.size(); ++i)
+            for (size_t i = 0; i < time_vector.size(); ++i)
                 outputFile << std::left << std::setw(10) << std::setprecision(2) << std::fixed << time_vector[i]
                            << std::right << std::setw(16) << std::setprecision(4) << std::fixed
                            << float_heave_position[i] << std::right << std::setw(16) << std::setprecision(4)

--- a/tests/regression/sphere/test_sphere_decay.cpp
+++ b/tests/regression/sphere/test_sphere_decay.cpp
@@ -138,7 +138,7 @@ int main(int argc, char* argv[]) {
                        //<< std::right << std::setw(18) << "Heave Vel (m/s)"
                        //<< std::right << std::setw(18) << "Heave Force (N)"
                        << std::endl;
-            for (int i = 0; i < time_vector.size(); ++i)
+            for (size_t i = 0; i < time_vector.size(); ++i)
                 outputFile << std::left << std::setw(12) << std::setprecision(6) << std::fixed << time_vector[i]
                            << std::right << std::setw(12) << std::setprecision(6) << std::fixed << heave_position[i]
                            << std::endl;

--- a/tests/regression/sphere/test_sphere_irreg_waves.cpp
+++ b/tests/regression/sphere/test_sphere_irreg_waves.cpp
@@ -203,7 +203,7 @@ int main(int argc, char* argv[]) {
             outputFile << std::left << std::setw(10) << "----------" << std::right << std::setw(12) << "----------"
                        << "\n";
 
-            for (int i = 0; i < time_vector.size(); i++) {
+            for (size_t i = 0; i < time_vector.size(); i++) {
                 outputFile << std::left << std::setw(10) << std::fixed << std::setprecision(3) << time_vector[i]
                            << std::right << std::setw(12) << std::fixed << std::setprecision(6) << heave_position[i]
                            << "\n";

--- a/tests/regression/sphere/test_sphere_irreg_waves_eta.cpp
+++ b/tests/regression/sphere/test_sphere_irreg_waves_eta.cpp
@@ -265,7 +265,7 @@ int main(int argc, char* argv[]) {
                 outputFile << std::left << std::setw(10) << "----------" << std::right << std::setw(12) << "----------"
                            << "\n";
 
-                for (int i = 0; i < time_vector.size(); i++) {
+                for (size_t i = 0; i < time_vector.size(); i++) {
                     outputFile << std::left << std::setw(10) << std::fixed << std::setprecision(3) << time_vector[i]
                                << std::right << std::setw(12) << std::fixed << std::setprecision(6) << heave_position[i]
                                << "\n";

--- a/tests/regression/sphere/test_sphere_reg_waves.cpp
+++ b/tests/regression/sphere/test_sphere_reg_waves.cpp
@@ -180,7 +180,7 @@ int main(int argc, char* argv[]) {
                            //<< std::right << std::setw(18) << "----------"
                            << "\n";
 
-                for (int i = 0; i < time_vector.size(); i++) {
+                for (size_t i = 0; i < time_vector.size(); i++) {
                     outputFile
                         << std::left << std::setw(10) << std::fixed << std::setprecision(3) << time_vector[i]
                         << std::right << std::setw(12) << std::fixed << std::setprecision(6)


### PR DESCRIPTION
Address MSVC warnings (C4005, C4018, C4189, C4267).

### Changes
- **C4005 (macro redefinition):** Remove conflicting `CHRONO_VERSION` macro; add fallback in `logger_backend.cpp`
- **C4018 (signed/unsigned mismatch):** Use `Eigen::Index` for Eigen containers, `size_t` for STL containers
- **C4267 (narrowing conversion):** Add explicit casts where APIs require `int`
- **C4189 (unused variable):** Remove `rest_length`, `col_dof`, `total_dofs`, `width_array`, etc.
- **Shadowing:** Rename `t_tau` → `t_tau_init` in `ExcitationConvolution`
- **Third-party:** Mark Irrlicht includes as `SYSTEM` in CMakeLists.txt

Tested: Release build, regression tests pass.