### PR TITLE
Bump version to 0.6.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] — 2026-02-19
+
+### Added
+
+- **State-space radiation damping** — alternative to convolution-based radiation that approximates RIRF kernels as a sum of exponential and oscillatory modes, reducing per-timestep cost from O(N) to O(1). New classes: `RadiationStateSpaceModel`, `RadiationStateSpaceFitter`, `RadiationStateSpaceComponent`
+- **`RadiationMethod` enum and `StateSpaceOptions` configuration struct** for selecting between convolution and state-space radiation at runtime
+- **YAML configuration keys** — `radiation_method`, `ss_max_order`, `ss_r2_threshold`, `output_kernel_fit`
+- **Kernel-fit diagnostics** — R² values and mode counts per DOF pair, optionally written to HDF5 output via `output_kernel_fit: true`
+- **Unit tests** for `RadiationStateSpaceModel` and `RadiationStateSpaceFitter`
+- **Regression tests** comparing state-space vs convolution for sphere decay, OSWEC decay, sphere irregular waves, and OSWEC irregular waves
+- **Frequency-domain excitation transfer function** for irregular waves — replaces time-domain convolution with a pre-computed transfer function, evaluating in O(N_freq) per DOF per timestep instead of O(N_irf × N_freq)
+
+### Changed
+
+- **Irregular wave model decoupled from simulation parameters** — removed `simulation_dt_` and `simulation_duration_` from `IrregularWaveParams`, eliminating the dependency that prevented adaptive time integration. `nfrequencies_` is now a required parameter.
+- **Removed redundant `num_bodies` from wave classes** — ownership moved to `WaveBase`, set automatically in `HydroSystem::AddWaves()`, simplifying the wave creation API and eliminating a source of configuration errors
+- Wave class code quality cleanup
+
+### Removed
+
+- Stale `include/hydroc/hydro_forces.h` (replaced by `hydro_system.h`)
+- Duplicate demo `demos/sphere/sphere_irreg_waves.cpp`
+
+### Fixed
+
+- **State-space fitter: order-1 fits were rejected** — the fitting loop started at order 2 and `FitFromSVD` explicitly rejected order < 2, so single-exponential kernels (rank-1 Hankel matrix) always returned invalid results
+
 ## [0.5.0] — 2026-02-16
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # ===============================================================================
 
 project(HydroChrono 
-    VERSION 0.5.0
+    VERSION 0.6.0
     DESCRIPTION "Hydrodynamics for Project Chrono."
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 <p align="center">
   <img src="docs/assets/img/hydrochrono_banner.png" />
   <br/>
-  <a href="https://github.com/NREL/HydroChrono/releases"><img src="https://img.shields.io/badge/version-v0.5-blue.svg" /></a>
+  <a href="https://github.com/NREL/HydroChrono/releases"><img src="https://img.shields.io/badge/version-v0.6-blue.svg" /></a>
   <a href="#"><img src="https://img.shields.io/badge/status-Prototype-orange.svg" /></a>
 </p>
 
-> ⚠️ HydroChrono is under active development (`v0.5` prototype). This early release focuses on a YAML‑driven CLI, real-time VSG visualization with animated free-surface rendering, and portable HDF5 outputs so you can try the code and share feedback. Expect rapid iteration over the coming year (inc. more advanced PTO, control, mooring & hydrodynamics) — please get in touch if you have any issues or feature requests.
+> ⚠️ HydroChrono is under active development (`v0.6` prototype). This early release focuses on a YAML‑driven CLI, real-time VSG visualization with animated free-surface rendering, and portable HDF5 outputs so you can try the code and share feedback. Expect rapid iteration over the coming year (inc. more advanced PTO, control, mooring & hydrodynamics) — please get in touch if you have any issues or feature requests.
 
 
 HydroChrono (Hydrodynamics for Project Chrono) is a hydrodynamics simulation toolkit built on [Project Chrono](https://projectchrono.org/). It is designed for simulating wave energy converters (WECs) and other complex ocean systems, and is **100% free and open‑source** end‑to‑end — no proprietary dependencies required. This repo ships a prototype, YAML‑driven CLI app for running simulations and exporting portable results.


### PR DESCRIPTION
Version bump in CMakeLists.txt, README badge, and README inline reference.

CHANGELOG entry for 0.6.0 covers both PRs merged since v0.5.0:
- #86: state-space radiation damping (model, fitter, component, config, YAML keys, diagnostics, unit tests, regression tests)
- #85: wave class cleanup (irregular wave decoupled from simulation params, num_bodies removed from wave API, frequency-domain excitation transfer function)