### PR TITLE
Bump version to 0.7.0 and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] — 2026-02-26
+
+### Added
+
+- **MoorDyn v2.6.1 mooring integration** — coupled MoorDyn as a Git submodule, enabling catenary and taut mooring analysis. New `MoorDynConfig` struct and `HydroSystem::SetMoorDynConfig()` API for mooring configuration.
+- **MoorDyn force coupling into HydroSystem** — mooring forces from MoorDyn are applied at each timestep alongside hydrostatic, radiation, and excitation forces
+- **RM3 mooring demonstration** — YAML-driven RM3 two-body point absorber with 3-line catenary mooring (6 MoorDyn segments: anchor–clump + clump–fairlead per line), runnable via `run_hydrochrono`
+- **Real-time mooring line visualization** — VSG GUI renders mooring line node positions queried from MoorDyn at each frame, with dynamic tension color mapping (blue-to-red gradient scaled to current tension range)
+- **RM3 mooring verification test** — automated CTest comparison against WEC-Sim/MoorDyn co-simulation reference data for body heave and fairlead tensions (correlation ≈ 0.998, max tension error ≈ 1.8% of mean)
+- **`hydroc/math_constants.h`** — centralised `M_PI` definition replacing scattered per-file definitions
+
+### Changed
+
+- **IRF truncation separated from smoothing and tapering** — `RadiationKernelProcessing` now treats truncation as a distinct step from the smoothing/tapering pipeline
+- **`RegularWave` encapsulation** — members made private with `SetPeriod()`/`SetOmega()` accessors
+
+### Fixed
+
+- **Cross-machine build robustness** — resolved HDF5 target name conflicts and Eigen3 detection issues affecting some build environments
+- **Chrono API and test infrastructure compatibility** — updated for recent Chrono API changes
+
 ## [0.6.0] — 2026-02-19
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 # ===============================================================================
 
 project(HydroChrono 
-    VERSION 0.6.0
+    VERSION 0.7.0
     DESCRIPTION "Hydrodynamics for Project Chrono."
     LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 <p align="center">
   <img src="docs/assets/img/hydrochrono_banner.png" />
   <br/>
-  <a href="https://github.com/NREL/HydroChrono/releases"><img src="https://img.shields.io/badge/version-v0.6-blue.svg" /></a>
+  <a href="https://github.com/NREL/HydroChrono/releases"><img src="https://img.shields.io/badge/version-v0.7-blue.svg" /></a>
   <a href="#"><img src="https://img.shields.io/badge/status-Prototype-orange.svg" /></a>
 </p>
 
-> ⚠️ HydroChrono is under active development (`v0.6` prototype). This early release focuses on a YAML‑driven CLI, real-time VSG visualization with animated free-surface rendering, and portable HDF5 outputs so you can try the code and share feedback. Expect rapid iteration over the coming year (inc. more advanced PTO, control, mooring & hydrodynamics) — please get in touch if you have any issues or feature requests.
-
+> ⚠️ HydroChrono is under active development (`v0.7` prototype). This early release focuses on a YAML‑driven CLI, real-time VSG visualization with animated free-surface rendering, MoorDyn mooring coupling, and portable HDF5 outputs so you can try the code and share feedback. Expect rapid iteration over the coming year (inc. more advanced PTO, control & hydrodynamics) — please get in touch if you have any issues or feature requests.
 
 HydroChrono (Hydrodynamics for Project Chrono) is a hydrodynamics simulation toolkit built on [Project Chrono](https://projectchrono.org/). It is designed for simulating wave energy converters (WECs) and other complex ocean systems, and is **100% free and open‑source** end‑to‑end — no proprietary dependencies required. This repo ships a prototype, YAML‑driven CLI app for running simulations and exporting portable results.
 

--- a/src/hydro/logging/logging.cpp
+++ b/src/hydro/logging/logging.cpp
@@ -297,7 +297,7 @@ void CLILogger::ShowBanner() {
     Log(LogLevel::Success, "│                                                                                                     │", LogColor::BrightCyan);
     Log(LogLevel::Success, "│                                   Hydrodynamics for Project Chrono                                  │", LogColor::White);
     Log(LogLevel::Success, "│                                                                                                     │", LogColor::BrightCyan);
-    Log(LogLevel::Success, "│  Version        : 0.5.0                                                                             │", LogColor::Gray);
+    Log(LogLevel::Success, "│  Version        : 0.7.0                                                                             │", LogColor::Gray);
     Log(LogLevel::Success, "│  Status         : Prototype                                                                         │", LogColor::Gray);
     Log(LogLevel::Success, "│  Author         : SEA-Stack Development Team                                                        │", LogColor::Gray);
     Log(LogLevel::Success, "│  Lead Developer : David Ogden                                                                       │", LogColor::Gray);


### PR DESCRIPTION
## Summary

- Bump project version from 0.6.0 to 0.7.0 across CMakeLists.txt, README badge, and CLI banner
- Add CHANGELOG entry for v0.7.0 covering MoorDyn mooring integration, visualization, verification, and related fixes
- Fix stale banner version in logging.cpp (was still showing 0.5.0)
- Update README prototype notice to reflect mooring as a shipped capability

## Changes

- `CMakeLists.txt` — `VERSION 0.6.0` → `0.7.0`
- `README.md` — version badge `v0.6` → `v0.7`; prototype notice updated to mention MoorDyn mooring coupling
- `src/hydro/logging/logging.cpp` — CLI banner version `0.5.0` → `0.7.0`
- `CHANGELOG.md` — new `[0.7.0]` section (Added, Changed, Fixed)

## Test plan

- Reran full CTest suite: regression, unit, and verification tests — all passed
- Regenerated the test results PDF
- Rebuilt the Windows package and ran the package test suite on two different Windows machines — all good